### PR TITLE
split bytes.ts into bytes.ts and buffers.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test2": "tap -Rspecy --no-bail --jobs=1 build/test/universal/*.test.js build/test/node/*.test.js",
     "test-coverage": "yarn test --coverage-report=lcov",
     "test-addresses": "tap -Rspecy --no-bail --jobs=1 build/test/universal/addresses.test.js",
+    "test-bytes-and-buffers": "tap -Rspecy --no-bail --jobs=1 build/test/universal/bytes.test.js build/test/universal/buffers.test.js",
     "test-crypto": "tap -Rspecy --no-bail --jobs=1 build/test/node/crypto.node.test.js",
     "watch-test": "onchange -i src/*.ts src/test/*.ts -- yarn build-and-test",
     "prepublishOnly": "yarn clean && yarn build",

--- a/src/crypto/crypto-driver-chloride.ts
+++ b/src/crypto/crypto-driver-chloride.ts
@@ -4,12 +4,14 @@ import {
     KeypairBytes,
 } from './crypto-types';
 import {
-    bufferToBytes,
-    bytesToBuffer,
     concatBytes,
     identifyBufOrBytes,
-    stringToBuffer
 } from '../util/bytes';
+import {
+    bufferToBytes,
+    bytesToBuffer,
+    stringToBuffer
+} from '../util/buffers';
 
 /**
  * A verison of the ILowLevelCrypto interface backed by Chloride.

--- a/src/crypto/crypto-driver-node.ts
+++ b/src/crypto/crypto-driver-node.ts
@@ -6,11 +6,13 @@ import {
 } from './crypto-types';
 import {
     b64StringToBytes,
+    concatBytes,
+} from '../util/bytes';
+import {
     bufferToBytes,
     bytesToBuffer,
-    concatBytes,
     stringToBuffer
-} from '../util/bytes';
+} from '../util/buffers';
 
 const _generateKeypairDerBytes = (): KeypairBytes => {
     // Generate a keypair in "der" format, which we will have to process

--- a/src/test/browser-run-exit.ts
+++ b/src/test/browser-run-exit.ts
@@ -12,7 +12,7 @@
 declare let window: any;
 let numFinished = 0;
 
-let numTestFiles = 12;  // <--- set this to the expected number of test files
+let numTestFiles = 13;  // <--- set this to the expected number of test files
 
 window.onFinish = (testName?: string) => {
     numFinished += 1;

--- a/src/test/shared-test-code/crypto-driver.shared.ts
+++ b/src/test/shared-test-code/crypto-driver.shared.ts
@@ -3,9 +3,11 @@ declare let window: any;
 
 import {
     identifyBufOrBytes,
-    stringToBuffer,
     stringToBytes
 } from '../../util/bytes';
+import {
+    stringToBuffer,
+} from '../../util/buffers';
 import {
     base32StringToBytes
 } from '../../crypto/base32';

--- a/src/test/universal/buffers.test.ts
+++ b/src/test/universal/buffers.test.ts
@@ -1,0 +1,81 @@
+import t = require('tap');
+// Boilerplate to help browser-run know when this test is completed (see browser-run.ts)
+// When run in the browser we'll be running tape, not tap, so we have to use tape's onFinish function..
+declare let window: any;
+if ((t.test as any).onFinish) {
+    (t.test as any).onFinish(() => window.onFinish('buffers'));
+}
+
+import {
+    bufferToBytes,
+    bufferToString,
+    bytesToBuffer,
+    stringToBuffer,
+} from '../../util/buffers';
+
+import {
+    identifyBufOrBytes,
+    isBytes,
+    isBuffer,
+} from '../../util/bytes';
+
+//================================================================================
+
+// use this unicode character for testing
+let snowmanString = '\u2603';  // ☃ \u2603  [0xe2, 0x98, 0x83] -- 3 bytes
+let snowmanBytes = Uint8Array.from([0xe2, 0x98, 0x83]);
+let snowmanBuffer = Buffer.from([0xe2, 0x98, 0x83]);
+
+let simpleString = 'aa';
+let simpleBytes = Uint8Array.from([97, 97]);
+let simpleBuffer = Buffer.from([97, 97]);
+
+//================================================================================
+
+t.test('bytesToBuffer', (t: any) => {
+    t.same(bytesToBuffer(snowmanBytes), snowmanBuffer, 'snowman bytes to buffer')
+    t.same(identifyBufOrBytes(bytesToBuffer(snowmanBytes)), 'buffer', 'returns buffer');
+    t.end();
+});
+
+t.test('bufferToBytes', (t: any) => {
+    t.same(bufferToBytes(snowmanBuffer), snowmanBytes, 'snowman buffer to bytes')
+    t.same(identifyBufOrBytes(bufferToBytes(snowmanBuffer)), 'bytes', 'returns bytes');
+    t.end();
+});
+
+//--------------------------------------------------
+
+t.test('bufferToString', (t: any) => {
+    t.same(bufferToString(simpleBuffer), simpleString, 'simple buffer to string');
+    t.same(bufferToString(snowmanBuffer), snowmanString, 'snowman buffer to string');
+    t.ok(typeof bufferToString(snowmanBuffer) === 'string', 'returns a string');
+    t.end();
+});
+
+t.test('stringToBuffer', (t: any) => {
+    t.same(stringToBuffer(simpleString), simpleBuffer, 'simple string to buffer');
+    t.same(stringToBuffer(snowmanString), snowmanBuffer, 'snowman string to buffer');
+    t.same(identifyBufOrBytes(stringToBuffer(snowmanString)), 'buffer', 'returns buffer');
+    t.end();
+});
+
+t.test('buffer: identifyBufOrBytes, isBuffer, isBytes', (t: any) =>{
+    let buf = Buffer.from([1]);
+    let bytes = Uint8Array.from([1]);
+    let other = [1, 2, 3];
+
+    t.same(identifyBufOrBytes(buf), 'buffer', 'can identify Buffer');
+    t.same(isBuffer(buf), true, 'isBuffer true');
+    t.same(isBytes(buf), false, 'isBytes false');
+
+    t.same(identifyBufOrBytes(bytes), 'bytes', 'can identify bytes');
+    t.same(isBuffer(bytes), false, 'isBuffer false');
+    t.same(isBytes(bytes), true, 'isBytes true');
+
+    t.same(identifyBufOrBytes(other as any), '?', 'is not tricked by other kinds of object');
+    t.same(isBuffer(other), false, 'isBuffer false on other');
+    t.same(isBytes(other), false, 'isBytes false on other');
+
+    t.end();
+});

--- a/src/test/universal/bytes.test.ts
+++ b/src/test/universal/bytes.test.ts
@@ -7,16 +7,12 @@ if ((t.test as any).onFinish) {
 }
 
 import {
-    bufferToBytes,
-    bufferToString,
-    bytesToBuffer,
     bytesToString,
     concatBytes,
     identifyBufOrBytes,
-    isBuffer,
     isBytes,
+    isBuffer,
     stringLengthInBytes,
-    stringToBuffer,
     stringToBytes,
 } from '../../util/bytes';
 
@@ -49,36 +45,6 @@ t.test('stringToBytes', (t: any) => {
 
 //--------------------------------------------------
 
-t.test('bytesToBuffer', (t: any) => {
-    t.same(bytesToBuffer(snowmanBytes), snowmanBuffer, 'snowman bytes to buffer')
-    t.same(identifyBufOrBytes(bytesToBuffer(snowmanBytes)), 'buffer', 'returns buffer');
-    t.end();
-});
-
-t.test('bufferToBytes', (t: any) => {
-    t.same(bufferToBytes(snowmanBuffer), snowmanBytes, 'snowman buffer to bytes')
-    t.same(identifyBufOrBytes(bufferToBytes(snowmanBuffer)), 'bytes', 'returns bytes');
-    t.end();
-});
-
-//--------------------------------------------------
-
-t.test('bufferToString', (t: any) => {
-    t.same(bufferToString(simpleBuffer), simpleString, 'simple buffer to string');
-    t.same(bufferToString(snowmanBuffer), snowmanString, 'snowman buffer to string');
-    t.ok(typeof bufferToString(snowmanBuffer) === 'string', 'returns a string');
-    t.end();
-});
-
-t.test('stringToBuffer', (t: any) => {
-    t.same(stringToBuffer(simpleString), simpleBuffer, 'simple string to buffer');
-    t.same(stringToBuffer(snowmanString), snowmanBuffer, 'snowman string to buffer');
-    t.same(identifyBufOrBytes(stringToBuffer(snowmanString)), 'buffer', 'returns buffer');
-    t.end();
-});
-
-//--------------------------------------------------
-
 t.test('stringLengthInBytes', (t: any) =>{
     t.same(stringLengthInBytes(simpleString), 2, 'simple string');
     t.same(stringLengthInBytes(snowmanString), 3, 'snowman string');
@@ -106,17 +72,17 @@ t.test('concatBytes', (t: any) =>{
 
 //--------------------------------------------------
 
-t.test('identifyBufOrBytes, isBuffer, isBytes', (t: any) =>{
-    let buf = Buffer.from([1]);
+t.test('bytes: identifyBufOrBytes, isBuffer, isBytes', (t: any) =>{
     let bytes = Uint8Array.from([1]);
+    let other = [1, 2, 3];
 
-    t.same(identifyBufOrBytes(buf), 'buffer', 'can identify Buffer');
-    t.same(identifyBufOrBytes(bytes), 'bytes', 'can identify Buffer');
-
-    t.same(isBuffer(buf), true, 'isBuffer true');
+    t.same(identifyBufOrBytes(bytes), 'bytes', 'can identify bytes');
     t.same(isBuffer(bytes), false, 'isBuffer false');
-    t.same(isBytes(buf), false, 'isBytes false');
     t.same(isBytes(bytes), true, 'isBytes true');
+
+    t.same(identifyBufOrBytes(other as any), '?', 'is not tricked by other kinds of object');
+    t.same(isBuffer(other), false, 'isBuffer false on other');
+    t.same(isBytes(other), false, 'isBytes false on other');
 
     t.end();
 });

--- a/src/util/buffers.ts
+++ b/src/util/buffers.ts
@@ -1,0 +1,20 @@
+/**
+ * This file provides common operations on Buffer.
+ * Any util function that uses a Buffer should be here, not in bytes.ts.
+ */
+
+//--------------------------------------------------
+
+export let bytesToBuffer = (bytes: Uint8Array): Buffer =>
+    Buffer.from(bytes);
+
+export let bufferToBytes = (buf: Buffer): Uint8Array =>
+    new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+
+//--------------------------------------------------
+
+export let stringToBuffer = (str: string): Buffer =>
+    Buffer.from(str, 'utf-8');
+
+export let bufferToString = (buf: Buffer): string =>
+    buf.toString('utf-8');


### PR DESCRIPTION
This will help us avoid pulling in the heavy polyfill for Buffers when we don't want it (in browsers).