### PR TITLE
add storage.overwriteAllDocsByAuthor(keypair) method and tests;

### DIFF
--- a/src/format-validators/format-validator-types.ts
+++ b/src/format-validators/format-validator-types.ts
@@ -36,6 +36,7 @@ export interface IFormatValidator {
      * Add an author signature to the document.
      * The input document needs a signature field to satisfy Typescript, but
      * it will be overwritten here, so you may as well just set signature: '' on the input.
+     * Return a copy of the original document with the signature field changed, or return a ValidationError.
      */
     signDocument(keypair: AuthorKeypair, doc: Doc): Doc | ValidationError;
 

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -17,6 +17,9 @@ import {
 import {
     IFormatValidator
 } from '../format-validators/format-validator-types';
+import {
+    ValidationError
+} from '../util/errors';
 
 import {
     Lock,
@@ -54,6 +57,16 @@ export interface IStorageAsync {
 
     // this should freeze the incoming doc if needed
     ingest(doc: Doc): Promise<IngestResultAndDoc>;
+
+    // Overwrite every doc from this author, including history versions, with an empty doc.
+    // The new docs will have a timestamp of (oldDoc.timestamp + 1) to prevent them from
+    //  jumping to the front of the history and becoming Latest.
+    // Return the number of docs changed, or a ValidationError.
+    // Already-empty docs will not be overwritten.
+    // If an error occurs this will stop early.
+    overwriteAllDocsByAuthor(keypair: AuthorKeypair): Promise<number | ValidationError>;
+
+    //--------------------------------------------------
 
     isClosed(): boolean;
     /**

--- a/src/util/doc-types.ts
+++ b/src/util/doc-types.ts
@@ -70,5 +70,6 @@ export interface DocToSet {
     workspace: WorkspaceAddress,
     path: Path,
     content: string,
+    timestamp?: number,
     deleteAfter?: number | null,
 }


### PR DESCRIPTION
This is about the same as `deleteMyDocs` from classic Earthstar.

Also added manual timestamp control to DocToSet -- now you can specify a timestamp for a doc when writing it.  If you omit the timestamp, as before, it chooses one for you which is Math.max(now, highestTimestampAtThatPath + 1) to make sure your write wins.