### PR TITLE
Add shim for TextEncoder / Decoder for node builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,7 +9,6 @@ const externals = [
   "sha256-uint8array",
   "tweetnacl",
   "superbus",
-  "util",
   "fast-json-stable-stringify"
 ];
 
@@ -49,6 +48,7 @@ const configs = [
     outfile: "dist/earthstar.cjs",
     target: ['es2017'],
     platform: "node",
+    inject: ["./src/shims/node.ts"],
     conditions: ["node"],
   },
   // universal, node, ESM
@@ -58,6 +58,7 @@ const configs = [
     target: ['es2017'],
     platform: "node",
     format: "esm",
+    inject: ["./src/shims/node.ts"],
     conditions: ["node"],
   },
   // node, CommonJS

--- a/src/shims/node.ts
+++ b/src/shims/node.ts
@@ -1,0 +1,2 @@
+export { TextDecoder, TextEncoder } from 'util'
+

--- a/src/test/browser-run-exit.ts
+++ b/src/test/browser-run-exit.ts
@@ -9,12 +9,12 @@
     When the expected number of files are finished, we quit.
 */
 
-declare let window: any;
+
 let numFinished = 0;
 
 let numTestFiles = 17;  // <--- set this to the expected number of test files
 
-window.onFinish = (testName?: string) => {
+var onFinish = (testName?: string) => {
     numFinished += 1;
     if (numFinished === 1) { console.log(' '); }
     console.log(`onFinish handler ${numFinished} / ${numTestFiles} ${testName ?? ''}`);

--- a/src/util/bytes.ts
+++ b/src/util/bytes.ts
@@ -6,26 +6,11 @@
  * when bundling for the browser.
  */
 
-declare let window: any;
-
 // TODO: remove this import after fixing b64String and hexString...
 import { bufferToBytes } from './buffers';
 
-// annoying workaround to get TextDecoder from Node or in browsers...
-import { TextDecoder, TextEncoder } from 'util';
-
-let decoder: TextDecoder;
-let encoder: TextEncoder;
-/* istanbul ignore next */ 
-if (TextDecoder !== undefined && TextEncoder !== undefined) {
-    // in node, it's in the 'util' package
-    decoder = new TextDecoder();
-    encoder = new TextEncoder();
-} else {
-    // in browser, it's a global on window
-    decoder = new window.TextDecoder();
-    encoder = new window.TextEncoder();
-}
+let decoder: TextDecoder = new TextDecoder;
+let encoder: TextEncoder = new TextEncoder;
 
 //--------------------------------------------------
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,33 @@
 {
-  "exclude":  ["node_modules", "build", "old", "ignore"],
+  "exclude": ["node_modules", "build", "old", "ignore"],
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2020"],                             /* Specify library files to be included in the compilation. */
+    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es2020",
+      "dom"
+    ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./build",                        /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "outDir": "./build" /* Redirect output structure to the directory. */,
+    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
-    "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    "importHelpers": true /* Import emit helpers from 'tslib'. */,
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -45,9 +48,11 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["node"],                           /* Type declaration files to be included in compilation. */
+    "types": [
+      "node"
+    ] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -63,6 +68,6 @@
 
     /* Advanced Options */
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
This PR modifies `src/util/bytes` so that it uses `TextEncoder` / `TextDecoder` in a naive way — that is, as though it is part of global scope on every platform.

To get around that not being the case on node, I've added a shim in `src/shims/node` which just re-exports `TextEncoder` and `TextDecoder` from the `util` package.

esbuild uses this shim with the node builds of the app using the inject feature.

The result of this is that the universal browser build no longer tries to import the node-only `util` package, and we can use `TextEncoder` and `TextDecoder` a little more easily throughout the codebase.

Other things:

- I added `dom` to the libraries in `tsconfig.json`. This makes it so that you don't need to define `window.TextEncoder`, as it's assumed that browser methods are available.
- Tests required a very minor change to keep them working!

Closes #38.

 
