### PR TITLE
add platform.node.ts & platform.browser.ts setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "dist/types/universal.d.ts",
   "browser": {
     "./build/index.js": "./build/index.browser.js",
+    "./build/platform.js": "./build/platform.browser.js",
     "./build/crypto/crypto-driver-node.js": false,
     "tap": "tape"
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,15 +2,15 @@ import esbuild from "esbuild";
 
 const externals = [
   "chalk",
+  "chloride",
   "fast-deep-equal",
+  "fast-json-stable-stringify",
   "rfc4648",
   "rfdc",
-  "chloride",
   "sha256-uint8array",
-  "tweetnacl",
   "superbus",
-  "util",
-  "fast-json-stable-stringify"
+  // tslib ?
+  "tweetnacl",
 ];
 
 const baseConfig = {

--- a/src/platform.browser.ts
+++ b/src/platform.browser.ts
@@ -1,0 +1,6 @@
+declare let window: any;
+
+export let PLATFORM = 'browser';
+
+export let textDecoder = new window.TextDecoder();
+export let textEncoder = new window.TextEncoder();

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,0 +1,7 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+export let PLATFORM = 'node';
+
+export let textDecoder: TextDecoder = new TextDecoder();
+export let textEncoder: TextEncoder = new TextEncoder();
+

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,1 @@
+platform.node.ts

--- a/src/util/bytes.ts
+++ b/src/util/bytes.ts
@@ -6,34 +6,21 @@
  * when bundling for the browser.
  */
 
-declare let window: any;
+import {
+    textDecoder,
+    textEncoder,
+} from '../platform';
 
 // TODO: remove this import after fixing b64String and hexString...
 import { bufferToBytes } from './buffers';
 
-// annoying workaround to get TextDecoder from Node or in browsers...
-import { TextDecoder, TextEncoder } from 'util';
-
-let decoder: TextDecoder;
-let encoder: TextEncoder;
-/* istanbul ignore next */ 
-if (TextDecoder !== undefined && TextEncoder !== undefined) {
-    // in node, it's in the 'util' package
-    decoder = new TextDecoder();
-    encoder = new TextEncoder();
-} else {
-    // in browser, it's a global on window
-    decoder = new window.TextDecoder();
-    encoder = new window.TextEncoder();
-}
-
 //--------------------------------------------------
 
 export let bytesToString = (bytes: Uint8Array): string =>
-    decoder.decode(bytes);
+    textDecoder.decode(bytes);
 
 export let stringToBytes = (str: string): Uint8Array =>
-    encoder.encode(str);
+    textEncoder.encode(str);
 
 //--------------------------------------------------
 


### PR DESCRIPTION
This is an alternate solution for the problem addressed by issue https://github.com/earthstar-project/stone-soup/issues/38 and PR https://github.com/earthstar-project/stone-soup/pull/39.

We want to access TextDecoder but need to do it differently on node vs. browsers.

I've created two files:
* `platform.browser.ts` -- gets TextDecoder in the browser way, and exports it
* `platform.node.ts` -- gets TextDecoder in the node way, and exports it

Any other platform-specific code could go in here, like lists of available StorageDrivers and CryptoDrivers (used by the test code).  There's still a similar set of `platform` files in the test directory which could be migrated over into these new more general platform files.

There's a symlink `platform.ts` which points at the node version by default.  All the code in the whole project imports from this symlink, `import { something } from 'platform'.

So, to build for different platforms, we need to swap out `platform.ts` for `platform.whatever.ts`.  
* `tsc`, which we use to run our node tests, uses the node version because that's where the symlink points.
* browser bundlers look at `package.json`'s `browser` field which swaps out for `platform.browser.ts`.  Therefore our browser tests work because they're built using browserify.
* esbuild might also look at that same `browser` field, or it might need extra config to swap out that one file, I'm not sure.  Help is wanted here to check on this.

I like this approach because it uses the standard `browser` field and doesn't depend on esbuild.  If someone comes along in 10 years and needs to just get this working, they can just change what the symlink is pointing at, by hand or from their build script.

It feels simple because it puts all the platform differences into one file, and it follows the same pattern as `index.ts` & `index.browser.ts`