### PR TITLE
Add Peer, PeerClient and PeerServer classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test-verbose": "tap -Rspecy --no-bail --jobs=1 build/test/universal/*.test.js build/test/node/*.test.js",
     "test-coverage": "yarn test --coverage-report=lcov",
     "test-crypto": "tap -Rspecy --no-bail --jobs=1 build/test/node/crypto.node.test.js",
+    "test-peer-client-server": "tap -Rspecy --no-bail --jobs=1 build/test/node/peer-client-server.node.test.js",
     "test-storage": "tap -Rspecy --no-bail --jobs=1 build/test/node/storage-async.node.test.js",
     "test-storage-driver": "tap -Rspecy --no-bail --jobs=1 build/test/node/storage-driver-async.node.test.js",
     "watch-test": "onchange -i src/*.ts src/test/*.ts -- yarn clean-build-and-test",
@@ -95,6 +96,7 @@
     "rfdc": "^1.2.0",
     "sha256-uint8array": "^0.10.1",
     "superbus": "^2.0.2",
+    "superbus-map": "^2.0.3",
     "tslib": "^2.2.0",
     "tweetnacl": "^1.0.3"
   }

--- a/src/example-app.ts
+++ b/src/example-app.ts
@@ -22,6 +22,9 @@ import {
 import {
     QueryFollower,
 } from './storage/query-follower';
+import {
+    Peer
+} from './peer/peer';
 
 //--------------------------------------------------
 
@@ -36,6 +39,7 @@ let loggerMain = new Logger('main', 'whiteBright');
 let loggerBusEvents = new Logger('main storage bus events', 'white');
 let loggerQueryFollowerCallbacks1 = new Logger('main query follower 1 callback', 'red');
 let loggerQueryFollowerCallbacks2 = new Logger('main query follower 2 callback', 'red');
+let loggerPeerMapEvents = new Logger('peer map event', 'redBright');
 
 setDefaultLogLevel(LogLevel.Debug);
 setLogLevel('main', LogLevel.Debug);
@@ -58,6 +62,13 @@ let main = async () => {
     let validator = new FormatValidatorEs4(crypto);
     let storageDriver = new StorageDriverAsyncMemory(workspace);
     let storage = new StorageAsync(workspace, validator, storageDriver);
+
+    let peer = new Peer();
+    peer.storageMap.bus.on('*', (channel, data) => {
+        loggerPeerMapEvents.debug(`${channel}`);
+    });
+    peer.addStorage(storage);
+
     loggerMain.info('generate a keypair')
     let keypair = crypto.generateAuthorKeypair('suzy');
     if (isErr(keypair)) {

--- a/src/peer/peer-client.ts
+++ b/src/peer/peer-client.ts
@@ -1,0 +1,103 @@
+import { WorkspaceAddress } from '../util/doc-types';
+import { ICrypto } from '../crypto/crypto-types';
+import {
+    IPeer,
+    IPeerClient,
+    IPeerServer,
+    PeerId,
+    StorageId,
+    saltAndHashWorkspace,
+} from './peer-types';
+
+import { microsecondNow } from '../util/misc';
+
+//--------------------------------------------------
+
+import { Logger } from '../util/log';
+let logger = new Logger('peer client', 'greenBright');
+let J = JSON.stringify;
+
+//================================================================================
+
+interface PeerInfo {
+    peerId: PeerId,
+    lastConnectedTimestamp: number,
+    commonWorkspaces: WorkspaceAddress[],
+    // TODO: we might want to access this by storageId, by workspace, or by peer + workspace...
+    storageInfos: Map<StorageId, StorageInfo>,
+}
+interface StorageInfo {
+    storageId: StorageId,
+    peerId: PeerId,
+    workspace: WorkspaceAddress,
+    maxLocalIndexReceived: number,
+    maxLocalIndexSent: number,
+    // TODO: how to find out what the server wants from us?
+}
+
+export class PeerClient implements IPeerClient {
+    // remember some things about each peer we've talked to
+    peerInfos: Map<PeerId, PeerInfo>;
+
+    constructor(public peer: IPeer, public crypto: ICrypto) {
+        this.peerInfos = new Map<PeerId, PeerInfo>();
+    }
+
+    async syncWithPeer(server: IPeerServer): Promise<void> {
+        logger.debug('sync');
+        let commonWorkspaces = await this.discoverCommonWorkspaces(server);
+        logger.debug(`...sync: got ${commonWorkspaces.length} common workspaces`);
+        for (let workspace of commonWorkspaces) {
+            logger.debug(`...sync: doing workspace "${workspace}"`);
+            logger.debug(`...(TODO)`);
+            // TODO: getDocuments(server, maxLocalIndex) and ingest them here
+            // TODO: push documents from us to the server (which docs?)
+        }
+        logger.debug('...sync: done');
+    }
+
+    async discoverCommonWorkspaces(server: IPeerServer): Promise<WorkspaceAddress[]> {
+        logger.debug(`discoverCommonWorkspaces`);
+
+        // talk to server.  get peerId and salted workspaces
+        let {
+            peerId: serverPeerId,
+            salt,
+            saltedWorkspaces: serverSaltedWorkspaces
+        } = await server.saltedWorkspaces();
+
+        // figure out which workspaces we have in common
+        let commonWorkspacesSet = new Set<string>();
+        let serverSaltedSet = new Set<string>(serverSaltedWorkspaces);
+        for (let myWorkspace of this.peer.workspaces()) {
+            let mySalted = saltAndHashWorkspace(this.crypto, salt, myWorkspace);
+            if (serverSaltedSet.has(mySalted)) {
+                commonWorkspacesSet.add(myWorkspace);
+            }
+        }
+        let commonWorkspaces = [...commonWorkspacesSet];
+        commonWorkspaces.sort();
+
+        // remember some facts about this server
+        logger.debug('server details before:', this.peerInfos.get(serverPeerId));
+        // load existing peerInfo
+        let peerInfo: PeerInfo = this.peerInfos.get(serverPeerId) ?? {
+            // ... or start with default empty peerInfo
+            peerId: serverPeerId,
+            lastConnectedTimestamp: -1,
+            commonWorkspaces: [],
+            storageInfos: new Map<StorageId, StorageInfo>(),
+        };
+        // update peerInfo
+        peerInfo = {
+            ...peerInfo,
+            lastConnectedTimestamp: microsecondNow(),
+            commonWorkspaces: commonWorkspaces,
+        }
+        this.peerInfos.set(serverPeerId, peerInfo);
+        logger.debug('server details after:', peerInfo);
+
+        logger.debug(`...${commonWorkspaces.length} common workspaces: ${J(commonWorkspaces)}`);
+        return commonWorkspaces;
+    }
+}

--- a/src/peer/peer-server.ts
+++ b/src/peer/peer-server.ts
@@ -1,0 +1,32 @@
+import { ICrypto } from '../crypto/crypto-types';
+import {
+    IPeer,
+    IPeerServer,
+    SaltAndSaltedWorkspaces,
+    saltAndHashWorkspace,
+} from './peer-types';
+
+//--------------------------------------------------
+
+import { Logger } from '../util/log';
+let logger = new Logger('peer server', 'yellowBright');
+let J = JSON.stringify;
+
+//================================================================================
+
+export class PeerServer implements IPeerServer {
+    constructor(public peer: IPeer, public crypto: ICrypto) {
+    }
+    async saltedWorkspaces(): Promise<SaltAndSaltedWorkspaces> {
+        let salt = '' + Math.random() + Math.random() + Math.random() + Math.random() + Math.random();
+        let saltedWorkspaces = this.peer.workspaces()
+            .map(ws => saltAndHashWorkspace(this.crypto, salt, ws));
+        let result = {
+            peerId: this.peer.peerId,
+            salt,
+            saltedWorkspaces,
+        }
+        logger.debug(`saltedWorkspaces: ${J(result, null, 2)}`);
+        return result;
+    }
+}

--- a/src/peer/peer-types.ts
+++ b/src/peer/peer-types.ts
@@ -1,0 +1,48 @@
+import { WorkspaceAddress } from '../util/doc-types';
+import { IStorageAsync } from '../storage/storage-types';
+import { ICrypto } from '../crypto/crypto-types';
+
+//================================================================================
+// PEER
+
+export type PeerId = string;
+export type StorageId = string;
+
+export interface IPeer {
+    // TODO: oops, or should we have storage IDs instead of peer IDs?
+    peerId: PeerId,
+
+    // getters
+    hasWorkspace(workspace: WorkspaceAddress): boolean;
+    workspaces(): WorkspaceAddress[];
+    storages(): IStorageAsync[];
+    size(): number;
+
+    // setters
+    addStorage(storage: IStorageAsync): Promise<void>;
+    removeStorageByWorkspace(workspace: WorkspaceAddress): Promise<void> 
+    removeStorage(storage: IStorageAsync): Promise<void>;
+}
+
+//================================================================================
+// CLIENT AND SERVER
+
+export interface SaltAndSaltedWorkspaces {
+    peerId: PeerId,
+    salt: string,
+    saltedWorkspaces: string[],
+}
+
+// ok this isn't a type, but I put it here anyway.
+export let saltAndHashWorkspace = (crypto: ICrypto, salt: string, workspace: WorkspaceAddress): string =>
+    crypto.sha256base32(salt + workspace + salt);
+
+// one server can talk to many clients.
+
+export interface IPeerClient {
+    discoverCommonWorkspaces(server: IPeerServer): Promise<WorkspaceAddress[]>;
+}
+
+export interface IPeerServer {
+    saltedWorkspaces(): Promise<SaltAndSaltedWorkspaces>
+}

--- a/src/peer/peer.ts
+++ b/src/peer/peer.ts
@@ -1,0 +1,77 @@
+import { SuperbusMap } from 'superbus-map';
+
+import { WorkspaceAddress } from '../util/doc-types';
+import { IStorageAsync } from '../storage/storage-types';
+import {
+    IPeer, PeerId,
+} from './peer-types';
+
+//--------------------------------------------------
+
+import { Logger } from '../util/log';
+let logger = new Logger('peer', 'blueBright');
+let J = JSON.stringify;
+
+//================================================================================
+
+
+//export type PeerEvent = 'close';
+
+export class Peer implements IPeer {
+    peerId: PeerId
+
+    //bus: Superbus<PeerEvent>;
+    storageMap: SuperbusMap<WorkspaceAddress, IStorageAsync>;
+    constructor() {
+        logger.debug('constructor');
+        //this.bus = new Superbus<PeerEvent>();
+        this.storageMap = new SuperbusMap<WorkspaceAddress, IStorageAsync>();
+        this.peerId = 'peer:' + Math.random();
+    }
+
+    //--------------------------------------------------
+    // getters
+
+    hasWorkspace(workspace: WorkspaceAddress): boolean {
+        return this.storageMap.has(workspace);
+    }
+    workspaces(): WorkspaceAddress[] {
+        let keys = [...this.storageMap.keys()];
+        keys.sort();
+        return keys;
+    }
+    storages(): IStorageAsync[] {
+        let keys = [...this.storageMap.keys()];
+        keys.sort();
+        return keys.map(key => this.storageMap.get(key) as IStorageAsync);
+    }
+    size(): number {
+        return this.storageMap.size;
+    }
+
+    //--------------------------------------------------
+    // setters
+
+    async addStorage(storage: IStorageAsync): Promise<void> {
+        logger.debug(`addStorage(${J(storage.workspace)})`);
+        if (this.storageMap.has(storage.workspace)) {
+            logger.debug(`already had a storage with that workspace`);
+            throw new Error(`Peer.addStorage: already has a storage with workspace ${J(storage.workspace)}.  Don't add another one.`);
+        }
+        await this.storageMap.set(storage.workspace, storage);
+        logger.debug(`    ...addStorage: done`);
+    }
+    async removeStorageByWorkspace(workspace: WorkspaceAddress): Promise<void> {
+        logger.debug(`removeStorageByWorkspace(${J(workspace)})`);
+        await this.storageMap.delete(workspace);
+    }
+    async removeStorage(storage: IStorageAsync): Promise<void> {
+        let existingStorage = this.storageMap.get(storage.workspace);
+        if (storage === existingStorage) {
+            logger.debug(`removeStorage(${J(storage.workspace)})`);
+            await this.removeStorageByWorkspace(storage.workspace);
+        } else {
+            logger.debug(`removeStorage(${J(storage.workspace)}) -- same workspace but it's a different instance now; ignoring`);
+        }
+    }
+}

--- a/src/storage/compare.ts
+++ b/src/storage/compare.ts
@@ -9,6 +9,11 @@ import {
 
 export type SortOrder = 'ASC' | 'DESC';
 
+export let sortedInPlace = <T>(array: T[]): T[] => {
+    array.sort();
+    return array;
+}
+
 // myStrings.sort(baseCompare)
 export let compareBasic = (a: any, b: any, order: SortOrder = 'ASC'): Cmp => {
     if (deepEqual(a, b)) { return Cmp.EQ; }

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -71,7 +71,7 @@ export class StorageAsync implements IStorageAsync {
         this.workspace = workspace;
         this.formatValidator = validator;
         this.storageDriver = driver;
-        this.bus = new Superbus<StorageEvent>();
+        this.bus = new Superbus<StorageEvent>('|');
     }
 
     async getDocsSinceLocalIndex(historyMode: HistoryMode, startAt: LocalIndex, limit?: number): Promise<Doc[]> {
@@ -267,7 +267,7 @@ export class StorageAsync implements IStorageAsync {
         // only send events if we successfully ingested a doc
         if (docIngested !== null) {
             loggerIngest.debug('  - ingest: send ingest event blockingly...');
-            await this.bus.sendAndWait('ingest', docIngested);
+            await this.bus.sendAndWait(('ingest|' + docIngested.path) as 'ingest', docIngested);
             loggerIngest.debug('  - ingest: ...done sending ingest event');
         }
 

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -28,7 +28,7 @@ import {
 //================================================================================
 
 export type StorageEvent =
-    'ingest' |
+    'ingest' |  // 'ingest|/some/path.txt'
     'willClose' | 'didClose';
 
 export interface IStorageAsync {

--- a/src/test/browser/peer-client-server.browser.test.ts
+++ b/src/test/browser/peer-client-server.browser.test.ts
@@ -1,0 +1,35 @@
+import { WorkspaceAddress } from '../../util/doc-types';
+import { IStorageAsync } from '../../storage/storage-types';
+
+import { Crypto } from '../../crypto/crypto';
+import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
+import { FormatValidatorEs4 } from '../../format-validators/format-validator-es4';
+import { StorageAsync } from '../../storage/storage-async';
+
+import { storageDriversAsync_browserAndUniversal } from './platform.browser';
+
+import { runPeerClientServerTests } from '../shared-test-code/peer-client-server.shared';
+import { runPeerTests } from '../shared-test-code/peer.shared';
+
+//================================================================================
+
+for (let storageDriver of storageDriversAsync_browserAndUniversal) {
+    // just hardcode this crypto driver since it works on all platforms
+    let cryptoDriver = CryptoDriverTweetnacl;
+
+    let storageDriverName = (storageDriver as any).name;
+    let cryptoDriverName = (cryptoDriver as any).name;
+    let description = `${storageDriverName} + ${cryptoDriverName}`;
+
+    let makeStorage = (ws: WorkspaceAddress): IStorageAsync => {
+        let crypto = new Crypto(cryptoDriver);
+        let validator = new FormatValidatorEs4(crypto);
+        let stDriver = new storageDriver(ws);
+        let storage = new StorageAsync(ws, validator, stDriver);
+        return storage;
+    }
+    let crypto = new Crypto(cryptoDriver);
+
+    runPeerTests(description, crypto, makeStorage);
+    runPeerClientServerTests(description, crypto, makeStorage);
+}

--- a/src/test/node/peer-client-server.node.test.ts
+++ b/src/test/node/peer-client-server.node.test.ts
@@ -1,0 +1,35 @@
+import { WorkspaceAddress } from '../../util/doc-types';
+import { IStorageAsync } from '../../storage/storage-types';
+
+import { Crypto } from '../../crypto/crypto';
+import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
+import { FormatValidatorEs4 } from '../../format-validators/format-validator-es4';
+import { StorageAsync } from '../../storage/storage-async';
+
+import { storageDriversAsync_nodeAndUniversal } from './platform.node';
+
+import { runPeerClientServerTests } from '../shared-test-code/peer-client-server.shared';
+import { runPeerTests } from '../shared-test-code/peer.shared';
+
+//================================================================================
+
+for (let storageDriver of storageDriversAsync_nodeAndUniversal) {
+    // just hardcode this crypto driver since it works on all platforms
+    let cryptoDriver = CryptoDriverTweetnacl;
+
+    let storageDriverName = (storageDriver as any).name;
+    let cryptoDriverName = (cryptoDriver as any).name;
+    let description = `${storageDriverName} + ${cryptoDriverName}`;
+
+    let makeStorage = (ws: WorkspaceAddress): IStorageAsync => {
+        let crypto = new Crypto(cryptoDriver);
+        let validator = new FormatValidatorEs4(crypto);
+        let stDriver = new storageDriver(ws);
+        let storage = new StorageAsync(ws, validator, stDriver);
+        return storage;
+    }
+    let crypto = new Crypto(cryptoDriver);
+
+    runPeerTests(description, crypto, makeStorage);
+    runPeerClientServerTests(description, crypto, makeStorage);
+}

--- a/src/test/shared-test-code/peer-client-server.shared.ts
+++ b/src/test/shared-test-code/peer-client-server.shared.ts
@@ -1,0 +1,83 @@
+import t = require('tap');
+import { onFinishOneTest } from '../browser-run-exit';
+
+import { WorkspaceAddress, } from '../../util/doc-types';
+import { IStorageAsync, } from '../../storage/storage-types';
+import { ICrypto } from '../../crypto/crypto-types';
+import { Peer } from '../../peer/peer';
+import { PeerClient } from '../../peer/peer-client';
+import { PeerServer } from '../../peer/peer-server';
+
+//================================================================================
+
+import {
+    Logger, LogLevel, setDefaultLogLevel, setLogLevel,
+} from '../../util/log';
+
+let loggerTest = new Logger('test', 'whiteBright');
+let loggerTestCb = new Logger('test cb', 'white');
+let J = JSON.stringify;
+
+//setDefaultLogLevel(LogLevel.None);
+//setLogLevel('peer client', LogLevel.Debug);
+//setLogLevel('peer server', LogLevel.Debug);
+
+//================================================================================
+
+export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, makeStorage: (ws: WorkspaceAddress) => IStorageAsync) => {
+
+    let TEST_NAME = 'peerClient + peerServer shared tests';
+    let SUBTEST_NAME = subtestName;
+
+    // Boilerplate to help browser-run know when this test is completed.
+    // When run in the browser we'll be running tape, not tap, so we have to use tape's onFinish function.
+    /* istanbul ignore next */ 
+    (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
+
+    t.test(SUBTEST_NAME + ': get workspaces in common', async (t: any) => {
+        let clientWorkspaces = [
+            '+common.one',
+            '+common.two',
+            '+common.three',
+            '+onlyclient.club',
+        ];
+        let serverWorkspaces = [
+            '+common.one',
+            '+onlyserver.club',
+            '+common.two',
+            '+common.three',
+        ]
+
+        let clientPeer = new Peer();
+        let serverPeer = new Peer();
+
+        t.notSame(clientPeer.peerId, serverPeer.peerId, 'peerIds are not the same');
+
+        // add storages
+        for (let ws of clientWorkspaces) {
+            let storage = makeStorage(ws);
+            clientPeer.addStorage(storage);
+        }
+        for (let ws of serverWorkspaces) {
+            let storage = makeStorage(ws);
+            serverPeer.addStorage(storage);
+        }
+
+        // create Client and Server instances
+        let client = new PeerClient(clientPeer, crypto);
+        let server = new PeerServer(serverPeer, crypto);
+
+        let wsInCommon = await client.discoverCommonWorkspaces(server);
+        t.same(wsInCommon, [
+            '+common.one',
+            '+common.three',
+            '+common.two',
+        ], `discovered correct workspaces in common, and they're sorted`);
+
+        // do it again just because doing so shouldn't break anything
+        let wsInCommon2 = await client.discoverCommonWorkspaces(server);
+        t.same(wsInCommon, wsInCommon2, 'same workspaces in common when run twice');
+
+        t.end();
+    });
+};

--- a/src/test/shared-test-code/peer.shared.ts
+++ b/src/test/shared-test-code/peer.shared.ts
@@ -1,0 +1,81 @@
+import t = require('tap');
+import { onFinishOneTest } from '../browser-run-exit';
+
+
+import { WorkspaceAddress, } from '../../util/doc-types';
+import { IStorageAsync, } from '../../storage/storage-types';
+import { ICrypto } from '../../crypto/crypto-types';
+import { compareByFn, sortedInPlace } from '../../storage/compare';
+import { Peer } from '../../peer/peer';
+
+//================================================================================
+
+import {
+    Logger,
+} from '../../util/log';
+
+let loggerTest = new Logger('test', 'whiteBright');
+let loggerTestCb = new Logger('test cb', 'white');
+let J = JSON.stringify;
+
+//setDefaultLogLevel(LogLevel.None);
+//setLogLevel('peer', LogLevel.Debug);
+
+//================================================================================
+
+export let runPeerTests = (subtestName: string, crypto: ICrypto, makeStorage: (ws: WorkspaceAddress) => IStorageAsync) => {
+
+    let TEST_NAME = 'peer shared tests';
+    let SUBTEST_NAME = subtestName;
+
+    // Boilerplate to help browser-run know when this test is completed.
+    // When run in the browser we'll be running tape, not tap, so we have to use tape's onFinish function.
+    /* istanbul ignore next */ 
+    (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
+
+    t.test(SUBTEST_NAME + ': peer basics', async (t: any) => {
+        let workspaces = [
+            '+one.ws',
+            '+two.ws',
+            '+three.ws',
+        ]
+        let storages = workspaces.map(ws => makeStorage(ws));
+
+        let sortedWorkspaces = sortedInPlace([...workspaces]);
+        let sortedStorages = [...storages];
+        sortedStorages.sort(compareByFn(storage => storage.workspace));
+
+        let peer = new Peer();
+
+        t.ok(typeof peer.peerId === 'string' && peer.peerId.length > 5, 'peer has a peerId');
+
+        t.same(peer.hasWorkspace('+two.ws'), false, 'does not yet have +two.ws');
+        t.same(peer.workspaces(), [], 'has no workspaces');
+        t.same(peer.storages(), [], 'has no storages');
+        t.same(peer.size(), 0, 'size is zero');
+
+        for (let storage of storages) {
+            await peer.addStorage(storage);
+        }
+
+        t.same(peer.hasWorkspace('nope'), false, 'does not have invalid workspace address');
+        t.same(peer.hasWorkspace('+nope.ws'), false, 'does not have +nope.ws workspace');
+        t.same(peer.hasWorkspace('+two.ws'), true, 'now it does have +two.ws');
+
+        t.same(peer.workspaces(), sortedWorkspaces, 'has all 3 workspaces, sorted');
+        t.same(peer.storages(), sortedStorages, 'has all 3 storages sorted by workspace');
+        t.same(peer.size(), 3, 'size is 3');
+
+        await peer.removeStorageByWorkspace('+one.ws');
+        t.same(peer.workspaces(), ['+three.ws', '+two.ws'], 'removed by workspace address');
+        t.same(peer.size(), 2, 'size is 2');
+
+        await peer.removeStorage(storages[1]);  // that's two.ws
+        t.same(peer.workspaces(), ['+three.ws'], 'removed storage instance');
+        t.same(peer.size(), 1, 'size is 1');
+
+        t.end();
+
+        // TODO: eventually test peer.bus events when we have them
+    });
+};

--- a/src/test/shared-test-code/storage-async.shared.ts
+++ b/src/test/shared-test-code/storage-async.shared.ts
@@ -22,6 +22,7 @@ import {
 
 let loggerTest = new Logger('test', 'whiteBright');
 let loggerTestCb = new Logger('test cb', 'white');
+let J = JSON.stringify;
 
 //================================================================================
 
@@ -30,8 +31,6 @@ let snowmanString = '\u2603';  // ☃ \u2603  [0xe2, 0x98, 0x83] -- 3 bytes
 let snowmanBytes = Uint8Array.from([0xe2, 0x98, 0x83]);
 
 //================================================================================
-
-let J = JSON.stringify;
 
 let throws = async (t: any, fn: () => Promise<any>, msg: string) => {
     try {

--- a/src/test/shared-test-code/storage-driver-async.shared.ts
+++ b/src/test/shared-test-code/storage-driver-async.shared.ts
@@ -20,6 +20,7 @@ import {
 } from '../../util/log';
 
 //setDefaultLogLevel(LogLevel.Debug);
+let J = JSON.stringify;
 
 //================================================================================
 
@@ -28,8 +29,6 @@ let snowmanString = '\u2603';  // ☃ \u2603  [0xe2, 0x98, 0x83] -- 3 bytes
 let snowmanBytes = Uint8Array.from([0xe2, 0x98, 0x83]);
 
 //================================================================================
-
-let J = JSON.stringify;
 
 export let runStorageDriverTests = (driverName: string, makeDriver: (ws: WorkspaceAddress) => IStorageDriverAsync) => {
 

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -79,7 +79,7 @@ export const updateLogLevels = (newLogLevels: LogLevels): void => {
 };
 
 export const setLogLevel = (source: LogSource, level: LogLevel) => {
-    setDefaultLogLevel(level);
+    globalLogLevels[source] = level;
 }
 
 export const setDefaultLogLevel = (level: LogLevel) => {
@@ -93,6 +93,9 @@ export const getLogLevel = (source: LogSource): LogLevel => {
         return globalLogLevels._default;
     }
 }
+
+export const getLogLevels = (): LogLevels =>
+    globalLogLevels;
 
 //================================================================================
 // Logger class

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,7 +3715,7 @@ rfc4648@^1.4.0:
   resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.4.0.tgz#c75b2856ad2e2d588b6ddb985d556f1f7f2a2abd"
   integrity sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg==
 
-rfdc@^1.2.0:
+rfdc@^1.2.0, rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
@@ -4237,6 +4237,15 @@ sumchecker@^3.0.1:
   integrity sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==
   dependencies:
     debug "^4.1.0"
+
+superbus-map@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/superbus-map/-/superbus-map-2.0.3.tgz#0ee1107c4c5c0547712ab58e0672af2d37c30473"
+  integrity sha512-WAJZvX26tFkKaVhyxoF6H/yUpoU0F1KvgrAFvOKJR/PJITuizW12NnXAO6nP+AUA4gm7dcNwKoxZWLVJZXQ1Qg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    rfdc "^1.3.0"
+    superbus "^2.0.2"
 
 superbus@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
New classes:

* Peer - holds a collection of Storage instances
* PeerClient - has a Peer, and can initiate conversations with a PeerServer
* PeerServer - has a (different) Peer, and passively responds to PeerClient's requests

So far, the only client-server conversation that happens is about finding common workspaces.  Next up will be actual syncing.

Peers have a `peerId` and Storages now have a `storageId`.  These are semi-persistent. They help us remember syncing progress so it can be resumed.  Peers and Storages can change their storageId at any time, but it might make syncing start over from scratch.

# TODO

* Add config key-value storage to Storage (setConfig, getConfig etc like in classic Earthstar)
* Use that to remember storageId
* Peers need some way to store their state too, but how... do we need to make a fake Storage for them so they can use setConfig/getConfig?
* Implement actual syncing
* Make a proxy version of PeerServer that actually reaches over the network behind the scenes, so this can run across the network