### PR TITLE
more organized rewrite of peer client and server

### DIFF
--- a/src/test/shared-test-code/peer-client-server.shared.ts
+++ b/src/test/shared-test-code/peer-client-server.shared.ts
@@ -20,12 +20,15 @@ let J = JSON.stringify;
 
 //setDefaultLogLevel(LogLevel.None);
 //setLogLevel('peer client', LogLevel.Debug);
+//setLogLevel('peer client: do', LogLevel.Debug);
+//setLogLevel('peer client: process', LogLevel.Debug);
+//setLogLevel('peer client: update', LogLevel.Debug);
 //setLogLevel('peer server', LogLevel.Debug);
+//setLogLevel('peer server: serve', LogLevel.Debug);
 
 //================================================================================
 
 export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, makeStorage: (ws: WorkspaceAddress) => IStorageAsync) => {
-
     let TEST_NAME = 'peerClient + peerServer shared tests';
     let SUBTEST_NAME = subtestName;
 
@@ -34,7 +37,7 @@ export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, mak
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': get workspaces in common', async (t: any) => {
+    t.test(SUBTEST_NAME + ': saltyHandshake', async (t: any) => {
         let clientWorkspaces = [
             '+common.one',
             '+common.two',
@@ -62,27 +65,11 @@ export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, mak
         }
 
         // create Client and Server instances
-        let client = new PeerClient(peerOnClient, crypto);
-        let server = new PeerServer(peerOnServer, crypto);
+        let server = new PeerServer(crypto, peerOnServer);
+        let client = new PeerClient(crypto, peerOnClient, server);
 
-        // let Client talk to Server
-        let commonWorkspacesAndServerPeerId = await client.discoverCommonWorkspacesAndServerPeerId(server);
-        t.same(commonWorkspacesAndServerPeerId, {
-            serverPeerId: peerOnServer.peerId,
-            commonWorkspaces: [
-                '+common.one',
-                '+common.three',
-                '+common.two',
-            ],
-        }, `discovered correct workspaces in common, and they're sorted`);
-
-        // do it again just because doing so shouldn't break anything
-        let commonWorkspacesAndServerPeerId2 = await client.discoverCommonWorkspacesAndServerPeerId(server);
-        t.same(
-            commonWorkspacesAndServerPeerId,
-            commonWorkspacesAndServerPeerId2,
-            'same workspaces in common when run twice'
-        );
+        // let them talk to each other
+        await client.do_saltyHandshake();
 
         // close Storages
         for (let storage of peerOnClient.storages()) { await storage.close(); }
@@ -90,3 +77,71 @@ export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, mak
         t.end();
     });
 };
+
+
+// export let runPeerClientServerTests = (subtestName: string, crypto: ICrypto, makeStorage: (ws: WorkspaceAddress) => IStorageAsync) => {
+// 
+//     let TEST_NAME = 'peerClient + peerServer shared tests';
+//     let SUBTEST_NAME = subtestName;
+// 
+//     // Boilerplate to help browser-run know when this test is completed.
+//     // When run in the browser we'll be running tape, not tap, so we have to use tape's onFinish function.
+//     /* istanbul ignore next */ 
+//     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
+// 
+//     t.test(SUBTEST_NAME + ': saltyHandshake', async (t: any) => {
+//         let clientWorkspaces = [
+//             '+common.one',
+//             '+common.two',
+//             '+common.three',
+//             '+onlyclient.club',
+//         ];
+//         let serverWorkspaces = [
+//             '+common.one',
+//             '+onlyserver.club',
+//             '+common.two',
+//             '+common.three',
+//         ]
+// 
+//         // make Peers
+//         let peerOnClient = new Peer();
+//         let peerOnServer = new Peer();
+//         t.notSame(peerOnClient.peerId, peerOnServer.peerId, 'peerIds are not the same');
+// 
+//         // make Storages and add them to the Peers
+//         for (let ws of clientWorkspaces) {
+//             peerOnClient.addStorage(makeStorage(ws));
+//         }
+//         for (let ws of serverWorkspaces) {
+//             peerOnServer.addStorage(makeStorage(ws));
+//         }
+// 
+//         // create Client and Server instances
+//         let client = new PeerClient(peerOnClient, crypto);
+//         let server = new PeerServer(peerOnServer, crypto);
+// 
+//         // let Client talk to Server
+//         let client_result_saltyHandshake = await client.client_request_saltyHandshake(server);
+//         t.same(client_result_saltyHandshake, {
+//             serverPeerId: peerOnServer.peerId,
+//             commonWorkspaces: [
+//                 '+common.one',
+//                 '+common.three',
+//                 '+common.two',
+//             ],
+//         }, `discovered correct workspaces in common, and they're sorted`);
+// 
+//         // do it again just because doing so shouldn't break anything
+//         let client_result_saltyHandshake2 = await client.client_request_saltyHandshake(server);
+//         t.same(
+//             client_result_saltyHandshake,
+//             client_result_saltyHandshake2,
+//             'same workspaces in common when run twice'
+//         );
+// 
+//         // close Storages
+//         for (let storage of peerOnClient.storages()) { await storage.close(); }
+//         for (let storage of peerOnServer.storages()) { await storage.close(); }
+//         t.end();
+//     });
+// };

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -17,4 +17,4 @@ export let sleep = (ms: number) =>
 
 // TODO: better randomness here
 export let randomId = (): string =>
-    '' + Math.random() + Math.random() + Math.random();
+    '' + Math.random() + Math.random();


### PR DESCRIPTION
(Note: this code has completely changed and the diff looks confusing; it's easier to read in side-by-side mode, and just look at the new stuff on the right-hand side.)

---

I've rewritten the [client and server code](https://github.com/earthstar-project/stone-soup/tree/peer-syncing/src/peer) completely to follow a more logical pattern.

A Peer is really just a collection of workspace storages.  It can have one or more Server and/or Client classes attached to it.  So every Server or Client is also called a Peer, loosely speaking.

So far we have one API, `saltyHandshake`, which is the first interaction between a client and server, and lets them figure out what workspaces they have in common (by comparing salted and hashed workspace strings).

All APIs will follow this pattern:

* The exchange is almost always initiated by the Client.
* Client and Peer have methods named `do_x`, `serve_x`, `process_x`, and `update_x`. 
* Along the way the data passes through the three types `x_Request`, `x_Response`, and `x_Outcome.`
* In the end, the Client's `update_x` method updates the internal state of the Client, which will be persisted to disk.  This is how we will remember syncing progress and resume from where we left off.

This is [described in more detail in peer-types.ts](https://github.com/earthstar-project/stone-soup/blob/peer-syncing/src/peer/peer-types.ts#L29-L48).

Here's what's printed by [the test code](https://github.com/earthstar-project/stone-soup/blob/peer-syncing/src/test/shared-test-code/peer-client-server.shared.ts) when run with
```sh
yarn clean-build && yarn test-peer-client-server
```

```
[peer server] peerServer constructor
[peer server] ...peerId: peer:0.13900299615007850.6443316120448932
[peer client] peerClient constructor
[peer client] ...peerId: peer:0.318146314212252260.8423863718198665
[peer client] ...client state:
[peer client] { serverPeerId: null, commonWorkspaces: null, lastSeenAt: null }
[peer client: do] do_saltyHandshake...
[peer client: do] ...asking server to serve_ ...
[peer server: serve] serve_saltyHandshake...
[peer server: serve] ...serve_saltyHandshake is done:
[peer server: serve] {
         serverPeerId: 'peer:0.13900299615007850.6443316120448932',
         salt: '0.89168151413693540.6743823660980011',
         saltedWorkspaces: [
             'bjd5cns3qbuvcyppysjhibkdfntwhr6scoviombtza7rsmo3qg6bq',
             'bu5ff2fuu3pcxc7grofa2pgwhomctqyerywvope7ypfsgikmpybta',
             'b2wsbyhqfu5qgld6iticinuj32fenfgpym4kf7gch2gir7zzdoubq',
             'bjzjmu6gs7ss6m4vjekl4tyf3wagr7sftzxutpwgjovwwaezte7aa'
         ]
     }
[peer client: do] ...client is going to process_ ...
[peer client: process] process_saltyHandshake...
[peer client: process] ...process_saltyHandshake is done:
[peer client: process] {
         serverPeerId: 'peer:0.13900299615007850.6443316120448932',
         commonWorkspaces: [ '+common.one', '+common.three', '+common.two' ]
     }
[peer client: do] ...client is going to update_ ...
[peer client: update] update_saltyHandshake...
[peer client: update] ...update_saltyHandshake is done.  client state is:
[peer client: update] {
         serverPeerId: 'peer:0.13900299615007850.6443316120448932',
         commonWorkspaces: [
             '+common.one',
             '+common.three',
             '+common.two'
         ],
         lastSeenAt: 1620868314297000
     }
[peer client: do] ...do_saltyHandshake is done
```