### PR TITLE
Peer syncing: add AllStorageStates API and tests

### DIFF
--- a/src/peer/peer-client.ts
+++ b/src/peer/peer-client.ts
@@ -11,6 +11,11 @@ import {
     SaltyHandshake_Response,
     initialPeerClientState,
     saltAndHashWorkspace,
+    AllStorageStates_Outcome,
+    AllStorageStates_Response,
+    AllStorageStates_Request,
+    ServerStorageSyncState,
+    ClientStorageSyncState,
 } from './peer-types';
 import { sortedInPlace } from '../storage/compare';
 
@@ -18,6 +23,8 @@ import { sortedInPlace } from '../storage/compare';
 
 import { Logger } from '../util/log';
 import { microsecondNow } from '../util/misc';
+import { NotImplementedError, ValidationError } from '../util/errors';
+import { RSA_NO_PADDING } from 'constants';
 let logger = new Logger('peer client', 'greenBright');
 let loggerDo = new Logger('peer client: do', 'green');
 let loggerProcess = new Logger('peer client: process', 'cyan');
@@ -70,6 +77,9 @@ export class PeerClient implements IPeerClient {
         return serverPeerId;
     }
 
+    //--------------------------------------------------
+    // SALTY HANDSHAKE
+
     // do the entire thing
     async do_saltyHandshake(): Promise<void> {
         loggerDo.debug('do_saltyHandshake...');
@@ -83,9 +93,6 @@ export class PeerClient implements IPeerClient {
         loggerDo.debug('...do_saltyHandshake is done');
     }
 
-    // this does any computation or complex work needed to boil this down
-    // into a simple state update, but it does not actually update our state,
-    // it just returns the changes to the state
     async process_saltyHandshake(res: SaltyHandshake_Response): Promise<SaltyHandshake_Outcome> {
         loggerProcess.debug('process_saltyHandshake...');
 
@@ -111,7 +118,6 @@ export class PeerClient implements IPeerClient {
         return outcome;
     }
 
-    // this applies the changes to the state
     async update_saltyHandshake(outcome: SaltyHandshake_Outcome): Promise<void> {
         loggerUpdate.debug('update_saltyHandshake...');
         await this.setState({
@@ -121,5 +127,83 @@ export class PeerClient implements IPeerClient {
         });
         loggerUpdate.debug('...update_saltyHandshake is done.  client state is:');
         loggerUpdate.debug(this.state);
+    }
+
+    //--------------------------------------------------
+    // ALL STORAGE STATES
+
+    async do_allStorageStates(): Promise<void> {
+        loggerDo.debug('do_allStorageStates...');
+        loggerDo.debug('...initial client state:');
+        loggerDo.debug(this.state);
+
+        // nothing to ask about?
+        if (this.state.commonWorkspaces === null || this.state.commonWorkspaces.length === 0) {
+            loggerDo.debug('...actually there are no common workspaces to ask about, so quitting early');
+            return;
+        }
+
+        let request: AllStorageStates_Request = {
+            commonWorkspaces: this.state.commonWorkspaces || [],
+        };
+        loggerDo.debug('...request:')
+        loggerDo.debug(request)
+
+        loggerDo.debug('...asking server to serve_ ...');
+        let response = await this.server.serve_allStorageStates(request);
+        loggerDo.debug('...response:')
+        loggerDo.debug(response);
+
+        loggerDo.debug('...client is going to process_ ...');
+        let outcome = await this.process_allStorageStates(response);
+        loggerDo.debug('...outcome:')
+        loggerDo.debug(outcome);
+
+        loggerDo.debug('...client is going to update_ ...');
+        await this.update_allStorageStates(outcome);
+        loggerDo.debug('...client state:');
+        loggerDo.debug(this.state);
+
+        loggerDo.debug('...do_allStorageStates is done');
+    }
+    async process_allStorageStates(res: AllStorageStates_Response): Promise<AllStorageStates_Outcome> {
+        loggerProcess.debug('process_allStorageStates...');
+        let clientStorageSyncStates: Record<WorkspaceAddress, ClientStorageSyncState> = this.state.clientStorageSyncStates || {};
+        for (let workspace of Object.keys(res)) {
+            loggerProcess.debug(`  > workspace: ${workspace}`);
+            let serverSyncState: ServerStorageSyncState = res[workspace];
+            loggerProcess.debug(`    ServerStorageSyncState: ${J(serverSyncState)}`);
+            if (workspace !== serverSyncState.workspaceAddress) {
+                throw new ValidationError('server shenanigans: server response is not self-consistent, workspace key does not match data in the Record');
+            }
+            let clientStorage = this.peer.getStorage(workspace);
+            if (clientStorage === undefined) {
+                throw new ValidationError('server shenanigans: referenced a workspace we don\'t have');
+            }
+            let existingClientSyncState = this.state.clientStorageSyncStates[workspace] || {};
+            let clientSyncState: ClientStorageSyncState = {
+                workspaceAddress: serverSyncState.workspaceAddress,
+                serverStorageId: serverSyncState.serverStorageId,
+                serverMaxLocalIndexOverall: serverSyncState.serverMaxLocalIndexOverall,
+                clientMaxLocalIndexOverall: clientStorage.getMaxLocalIndex(),
+                // set maxIndexSoFar to -1 if it's missing, otherwise preserve the old value
+                serverMaxLocalIndexSoFar: existingClientSyncState.serverMaxLocalIndexOverall ?? -1,
+                clientMaxLocalIndexSoFar: existingClientSyncState.clientMaxLocalIndexOverall ?? -1,
+                lastSeenAt: microsecondNow(),
+            }
+            loggerProcess.debug(`    new clientSyncState: ${J(clientSyncState)}`);
+            clientStorageSyncStates[workspace] = clientSyncState;
+        }
+        loggerProcess.debug('...process_allStorageStates is done');
+        return clientStorageSyncStates;
+    }
+    async update_allStorageStates(outcome: AllStorageStates_Outcome): Promise<void> {
+        loggerUpdate.debug('updateAllStorageStates');
+        loggerUpdate.debug('...just doing a setState...');
+        this.setState({
+            clientStorageSyncStates: outcome,
+            lastSeenAt: microsecondNow(),
+        });
+        loggerUpdate.debug('...updateAllStorageStates is done');
     }
 }

--- a/src/peer/peer-server.ts
+++ b/src/peer/peer-server.ts
@@ -6,6 +6,9 @@ import {
     SaltyHandshake_Request,
     SaltyHandshake_Response,
     saltAndHashWorkspace,
+    AllStorageStates_Request,
+    AllStorageStates_Response,
+    ServerStorageSyncState,
 } from "./peer-types";
 import { randomId } from '../util/misc';
 
@@ -45,6 +48,25 @@ export class PeerServer implements IPeerServer {
         }
         loggerServe.debug('...serve_saltyHandshake is done:');
         loggerServe.debug(response);
+        return response;
+    }
+    async serve_allStorageStates(req: AllStorageStates_Request): Promise<AllStorageStates_Response> {
+        loggerServe.debug('serve_allStorageStates...')
+        let response: AllStorageStates_Response = {};
+        for (let workspace of req.commonWorkspaces) {
+            let storage = this.peer.getStorage(workspace);
+            if (storage === undefined) {
+                loggerServe.debug(`workspace ${workspace} is unknown; skipping`);
+                continue;
+            }
+            let storageState: ServerStorageSyncState = {
+                workspaceAddress: workspace,
+                serverStorageId: storage.storageId,
+                serverMaxLocalIndexOverall: storage.getMaxLocalIndex(),
+            };
+            response[workspace] = storageState;
+        }
+        loggerServe.debug('...serve_allStorageStates is done')
         return response;
     }
 }

--- a/src/peer/peer.ts
+++ b/src/peer/peer.ts
@@ -50,6 +50,9 @@ export class Peer implements IPeer {
     size(): number {
         return this.storageMap.size;
     }
+    getStorage(ws: WorkspaceAddress): IStorageAsync | undefined {
+        return this.storageMap.get(ws);
+    }
 
     //--------------------------------------------------
     // setters

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -151,7 +151,7 @@ export class QueryFollower implements IQueryFollower {
      * changes from the Storage?
      */
     isCaughtUp(): boolean {
-        return this._maxLocalIndex >= this.storage.storageDriver.getMaxLocalIndex();
+        return this._maxLocalIndex >= this.storage.getMaxLocalIndex();
     }
 
     async _catchUp(): Promise<void> {

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -120,6 +120,11 @@ export class StorageAsync implements IStorageAsync {
     //--------------------------------------------------
     // GET
 
+    // one of the few that's synchronous
+    getMaxLocalIndex(): number {
+        return this.storageDriver.getMaxLocalIndex();
+    }
+
     async getDocsAfterLocalIndex(historyMode: HistoryMode, startAfter: LocalIndex, limit?: number): Promise<Doc[]> {
         logger.debug(`getDocsAfterLocalIndex(${historyMode}, ${startAfter}, ${limit})`);
         if (this._isClosed) { throw new StorageIsClosedError(); }

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -73,6 +73,9 @@ export interface IStorageAsync extends IStorageAsyncConfig {
     //--------------------------------------------------
     // GET
 
+    // this one is synchronous
+    getMaxLocalIndex(): number;
+
     // these should all return frozen docs
     getDocsAfterLocalIndex(historyMode: HistoryMode, startAfter: LocalIndex, limit?: number): Promise<Doc[]>;
     getAllDocs(): Promise<Doc[]>;
@@ -108,6 +111,8 @@ export interface IStorageDriverAsync extends IStorageAsyncConfig {
     //--------------------------------------------------
     // LIFECYCLE
 
+    // TODO: hatch (and load maxLocalIndex)
+
     isClosed(): boolean;
     // the IStorage will call this
     close(): Promise<void>;
@@ -115,7 +120,10 @@ export interface IStorageDriverAsync extends IStorageAsyncConfig {
     //--------------------------------------------------
     // GET
 
-    // The max local index used so far.  the first doc will increment this and get index 1.
+    // The max local index used so far.
+    // The first doc will increment this and get index 1.
+    // This is synchronous because it's expected that the driver will
+    // load it once at startup and then keep it in memory.
     getMaxLocalIndex(): number;
 
     // this should return frozen docs


### PR DESCRIPTION
The overall API sequence between PeerClient and PeerServer will be something like:

- [x] `SaltyHandshake` - get common workspaces and peerId
- [ ] `AllStorageStates` - get storageId and number of docs in each storage, all at once (for common workspaces)
- [ ] `DocsSince`- this will be called for each workspace.  Get docs from one storage starting after the last known downloaded localIndex, and push docs starting after the last known sent localIndex.

This PR adds `AllStorageStates`.

* Client asks the server about some workspace addresses (in plaintext, previously safely obtained from SaltyHandshake)
* Server replies with info about each workspace's Storage:
    * its storage ID
    * its max local index (e.g. how many total things it has, so we can show a progress bar for syncing)
* Client updates it local state with this info, plus `lastSeenAt` timestamps

The client state will also hold the highest localIndex that we've sent, and the highest that we've received, from a given storage.  That's how we'll resume syncing from where we left off.  But that's not set here since we're not syncing any documents, it's just initialized to -1.

(Along the way I added a new method to StorageAsync: `getMaxLocalIndex`.  It's a passthrough to the storage driver which has a method of the same name.  Now we can just ask the StorageAsync for that number instead of diving deep through into the driver to get it.)