### PR TITLE
Add overwriteAllDocsByAuthor to StorageCache

### DIFF
--- a/src/storage/storage-cache.ts
+++ b/src/storage/storage-cache.ts
@@ -7,8 +7,7 @@ import { microsecondNow } from "../util/misc";
 import { docMatchesFilter, cleanUpQuery } from "../query/query";
 import { QueryFollower } from "../query-follower/query-follower";
 import { Query } from "../query/query-types";
-import { StorageAsync } from "./storage-async";
-import { IngestResult, IngestResultAndDoc } from "./storage-types";
+import { IngestResult, IngestResultAndDoc, IStorageAsync } from "./storage-types";
 import { Crypto } from "../crypto/crypto";
 
 //--------------------------------------------------
@@ -85,7 +84,7 @@ function sortAndLimit(query: Query, docs: Doc[]) {
 }
 
 export class StorageCache {
-  _storage: StorageAsync;
+  _storage: IStorageAsync;
 
   _docCache = new Map<
     string,
@@ -96,7 +95,7 @@ export class StorageCache {
 
   _onCacheUpdatedCallbacks = new Set<() => void | (() => Promise<void>)>();
 
-  constructor(storage: StorageAsync, timeToLive?: number) {
+  constructor(storage: IStorageAsync, timeToLive?: number) {
     this._storage = storage;
     this._timeToLive = timeToLive || 1000;
   }

--- a/src/storage/storage-cache.ts
+++ b/src/storage/storage-cache.ts
@@ -1,20 +1,20 @@
 import isEqual from "fast-deep-equal";
-import stringify from 'fast-json-stable-stringify'
+import stringify from "fast-json-stable-stringify";
 
 import { AuthorKeypair, Doc, DocToSet, Path } from "../util/doc-types";
-import { isErr, StorageIsClosedError } from "../util/errors";
+import { isErr, StorageIsClosedError, ValidationError } from "../util/errors";
 import { microsecondNow } from "../util/misc";
 import { docMatchesFilter, cleanUpQuery } from "../query/query";
 import { QueryFollower } from "../query-follower/query-follower";
 import { Query } from "../query/query-types";
 import { StorageAsync } from "./storage-async";
 import { IngestResult, IngestResultAndDoc } from "./storage-types";
-import { Crypto } from '../crypto/crypto';
+import { Crypto } from "../crypto/crypto";
 
 //--------------------------------------------------
 
-import { Logger } from '../util/log';
-let logger = new Logger('storage cache', 'cyan');
+import { Logger } from "../util/log";
+let logger = new Logger("storage cache", "cyan");
 
 //================================================================================
 
@@ -29,7 +29,10 @@ function sortAndLimit(query: Query, docs: Doc[]) {
   for (let doc of docs) {
     if (query.orderBy === "path ASC") {
       if (query.startAfter !== undefined) {
-        if (query.startAfter.path !== undefined && doc.path <= query.startAfter.path) {
+        if (
+          query.startAfter.path !== undefined &&
+          doc.path <= query.startAfter.path
+        ) {
           continue;
         }
         // doc.path is now > startAfter.path
@@ -37,7 +40,10 @@ function sortAndLimit(query: Query, docs: Doc[]) {
     }
     if (query.orderBy === "path DESC") {
       if (query.startAfter !== undefined) {
-        if (query.startAfter.path !== undefined && doc.path >= query.startAfter.path) {
+        if (
+          query.startAfter.path !== undefined &&
+          doc.path >= query.startAfter.path
+        ) {
           continue;
         }
         // doc.path is now < startAfter.path (we're descending)
@@ -81,15 +87,18 @@ function sortAndLimit(query: Query, docs: Doc[]) {
 export class StorageCache {
   _storage: StorageAsync;
 
-  _docCache = new Map<string, { docs: Doc[]; follower: QueryFollower, expires: number }>();
-  
+  _docCache = new Map<
+    string,
+    { docs: Doc[]; follower: QueryFollower; expires: number }
+  >();
+
   _timeToLive: number;
 
   _onCacheUpdatedCallbacks = new Set<() => void | (() => Promise<void>)>();
 
   constructor(storage: StorageAsync, timeToLive?: number) {
     this._storage = storage;
-    this._timeToLive = timeToLive || 1000
+    this._timeToLive = timeToLive || 1000;
   }
 
   // GET
@@ -159,10 +168,14 @@ export class StorageCache {
       this._storage.queryDocs(query).then((docs) => {
         this._docCache.set(queryString, { ...cachedResult, docs });
       });
-      
+
       if (Date.now() > cachedResult.expires) {
         this._storage.queryDocs(query).then((docs) => {
-          this._docCache.set(queryString, { follower, docs, expires: Date.now() + this._timeToLive });
+          this._docCache.set(queryString, {
+            follower,
+            docs,
+            expires: Date.now() + this._timeToLive,
+          });
           logger.debug("⌛️");
           this._fireOnCacheUpdateds();
         });
@@ -187,14 +200,18 @@ export class StorageCache {
     this._docCache.set(queryString, {
       docs: [],
       follower,
-      expires: Date.now() + this._timeToLive
+      expires: Date.now() + this._timeToLive,
     });
 
     // Hatch the follower.
     follower.hatch();
-    
+
     this._storage.queryDocs(query).then((docs) => {
-      this._docCache.set(queryString, { follower, docs, expires: Date.now() + this._timeToLive });
+      this._docCache.set(queryString, {
+        follower,
+        docs,
+        expires: Date.now() + this._timeToLive,
+      });
       logger.debug("👹");
       this._fireOnCacheUpdateds();
     });
@@ -243,6 +260,62 @@ export class StorageCache {
     };
   }
 
+  // OVERWRITE
+
+  overwriteAllDocsByAuthor(keypair: AuthorKeypair): number | ValidationError {
+    if (this._storage.isClosed()) {
+      throw new StorageIsClosedError();
+    }
+
+    this._storage.overwriteAllDocsByAuthor(keypair);
+
+    let docsToOverwrite = new Set(
+      Array.from(this._docCache.values()).flatMap((cache) => {
+        return cache.docs.filter((doc) => doc.author === keypair.address);
+      })
+    );
+
+    let numOverwritten = 0;
+
+    console.log({ docsToOverwrite });
+
+    for (let doc of docsToOverwrite) {
+      if (doc.content.length === 0) {
+        continue;
+      }
+
+      // remove extra fields
+      let cleanedResult = this._storage.formatValidator.removeExtraFields(doc);
+      if (isErr(cleanedResult)) {
+        return cleanedResult;
+      }
+      let cleanedDoc = cleanedResult.doc;
+
+      // make new doc which is empty and just barely newer than the original
+      let emptyDoc: Doc = {
+        ...cleanedDoc,
+        content: "",
+        contentHash: Crypto.sha256base32(""),
+        timestamp: doc.timestamp + 1,
+        signature: "?",
+      };
+
+      // sign and ingest it
+      let signedDoc = this._storage.formatValidator.signDocument(
+        keypair,
+        emptyDoc
+      );
+      if (isErr(signedDoc)) {
+        return signedDoc;
+      }
+
+      this._updateCacheOptimistically(signedDoc);
+      numOverwritten += 1;
+    }
+
+    return numOverwritten;
+  }
+
   // CACHE
 
   // Update cache entries as best as we can until results from the backing storage arrive.
@@ -280,7 +353,10 @@ export class StorageCache {
       const appendDoc = () => {
         logger.debug("🥞");
         let nextDocs = [...entry.docs, doc];
-        this._docCache.set(key, { ...entry, docs: sortAndLimit(query, nextDocs) });
+        this._docCache.set(key, {
+          ...entry,
+          docs: sortAndLimit(query, nextDocs),
+        });
         this._fireOnCacheUpdateds();
       };
 
@@ -300,13 +376,17 @@ export class StorageCache {
           return existingDoc;
         });
 
-        this._docCache.set(key, { ...entry, docs: sortAndLimit(query,nextDocs) });
+        this._docCache.set(key, {
+          ...entry,
+          docs: sortAndLimit(query, nextDocs),
+        });
         this._fireOnCacheUpdateds();
       };
 
       const documentsWithSamePath = entry.docs.filter(
         (existingDoc) => existingDoc.path === doc.path
       );
+
       const documentsWithSamePathAndAuthor = entry.docs.filter(
         (existingDoc) =>
           existingDoc.path === doc.path && existingDoc.author === doc.author
@@ -330,18 +410,22 @@ export class StorageCache {
           return;
         }
 
-        logger.debug('🕰')
+        logger.debug("🕰");
         replaceDoc({ exact: true });
         return;
       }
 
       const latestDoc = documentsWithSamePath[0];
 
-      const docIsDifferent =
-        doc.author !== latestDoc?.author || isEqual(doc, latestDoc);
+      // console.log({latestDoc, doc})
 
-      if (docIsDifferent) {
-        logger.debug('⌚️')
+      const docIsDifferent =
+        doc.author !== latestDoc?.author || !isEqual(doc, latestDoc);
+
+      const docIsLater = doc.timestamp > latestDoc.timestamp;
+
+      if (docIsDifferent && docIsLater) {
+        logger.debug("⌚️");
         replaceDoc({ exact: false });
         return;
       }

--- a/src/test/universal/storage-cache.test.ts
+++ b/src/test/universal/storage-cache.test.ts
@@ -91,13 +91,6 @@ t.test("works", (t: any) => {
   t.equals(values.latestDocs.length, 3);
   t.equals(values.orangesDoc?.path, "/test/oranges.txt");
   t.equals(values.orangesDoc?.author, keypairB.address);
-  
-  cache.overwriteAllDocsByAuthor(keypair);
-  
-  t.equals(values.allDocs.length, 4);
-  t.equals(values.latestDocs.length, 3);
-  t.equals(values.allDocs.filter((doc) => doc.author === keypair.address).every((doc) => doc.content === ''), true)
-  t.equals(values.latestDocs.filter((doc) => doc.author === keypair.address).every((doc) => doc.content === ''), true)
 
   t.end();
 });

--- a/src/test/universal/storage-cache.test.ts
+++ b/src/test/universal/storage-cache.test.ts
@@ -91,6 +91,13 @@ t.test("works", (t: any) => {
   t.equals(values.latestDocs.length, 3);
   t.equals(values.orangesDoc?.path, "/test/oranges.txt");
   t.equals(values.orangesDoc?.author, keypairB.address);
+  
+  cache.overwriteAllDocsByAuthor(keypair);
+  
+  t.equals(values.allDocs.length, 4);
+  t.equals(values.latestDocs.length, 3);
+  t.equals(values.allDocs.filter((doc) => doc.author === keypair.address).every((doc) => doc.content === ''), true)
+  t.equals(values.latestDocs.filter((doc) => doc.author === keypair.address).every((doc) => doc.content === ''), true)
 
   t.end();
 });


### PR DESCRIPTION
`StorageCache` did not have an analogue for `overwriteAllDocsByAuthor`. Here I've added one which, like the other methods in `StorageCache`, works synchronously with the current cache while calling the real storage in the background.

Do we want this, though?

While it's nice to be able to see all documents disappear immediately upon calling, someone overwriting all their documents probably wants to be sure that the operation _actually_ succeeded, and is ready to propagate. Maybe this implementation creates a false impression that it has, when really they may need to wait a little longer.

While I think it's still preferable for the querying methods of StorageCache to have the same API as StorageAsync, maybe the mutating methods should return promises so that it's possible to tell when the operation has truly completed. 

What do you think?

