### PR TITLE
Add StorageDriverLocalStorage

### DIFF
--- a/src/entries/browser.ts
+++ b/src/entries/browser.ts
@@ -1,4 +1,1 @@
-// IndexedDB goes in here some day.
-
-export const FakeIndexedDbStorage = {};
-export const FakeWebCryptoDriver = {};
+export { StorageDriverLocalStorage} from '../storage/storage-driver-local-storage'

--- a/src/storage/storage-driver-local-storage.ts
+++ b/src/storage/storage-driver-local-storage.ts
@@ -2,8 +2,8 @@ import { Doc, Path, WorkspaceAddress } from "../util/doc-types";
 import { StorageDriverAsyncMemory } from "./storage-driver-async-memory";
 
 type SerializedDriverDocs = {
-  byPathAndAuthor: Map<string, Doc>;
-  byPathNewestFirst: Map<Path, Doc[]>;
+  byPathAndAuthor: Record<string, Doc>;
+  byPathNewestFirst: Record<Path, Doc[]>;
 };
 
 function isSerializedDriverDocs(value: any): value is SerializedDriverDocs {
@@ -13,9 +13,7 @@ function isSerializedDriverDocs(value: any): value is SerializedDriverDocs {
 
   if (
     "byPathAndAuthor" in value &&
-    "byPathNewestFirst" in value &&
-    value.byPathAndAuthor instanceof Map &&
-    value.byPathNewestFirst instanceof Map
+    "byPathNewestFirst" in value
   ) {
     return true;
   }
@@ -42,8 +40,8 @@ export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
         return;
       }
 
-      this.docByPathAndAuthor = parsed.byPathAndAuthor;
-      this.docsByPathNewestFirst = parsed.byPathNewestFirst;
+      this.docByPathAndAuthor = new Map(Object.entries(parsed.byPathAndAuthor));
+      this.docsByPathNewestFirst = new Map(Object.entries(parsed.byPathNewestFirst));
     }
   }
 
@@ -73,8 +71,8 @@ export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
     let upsertedDoc = super.upsert(doc);
 
     const docsToBeSerialised: SerializedDriverDocs = {
-      byPathAndAuthor: this.docByPathAndAuthor,
-      byPathNewestFirst: this.docsByPathNewestFirst,
+      byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
+      byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
     };
 
     // Todo: Debouncing of writing in-memory values to localStorage.

--- a/src/storage/storage-driver-local-storage.ts
+++ b/src/storage/storage-driver-local-storage.ts
@@ -1,0 +1,88 @@
+import { Doc, Path, WorkspaceAddress } from "../util/doc-types";
+import { StorageDriverAsyncMemory } from "./storage-driver-async-memory";
+
+type SerializedDriverDocs = {
+  byPathAndAuthor: Map<string, Doc>;
+  byPathNewestFirst: Map<Path, Doc[]>;
+};
+
+function isSerializedDriverDocs(value: any): value is SerializedDriverDocs {
+  if (typeof value !== "object") {
+    return false;
+  }
+
+  if (
+    "byPathAndAuthor" in value &&
+    "byPathNewestFirst" in value &&
+    value.byPathAndAuthor instanceof Map &&
+    value.byPathNewestFirst instanceof Map
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
+  _localStorageKeyConfig: string;
+  _localStorageKeyDocs: string;
+
+  constructor(workspace: WorkspaceAddress) {
+    super(workspace);
+
+    this._localStorageKeyConfig = `earthstar:config:${workspace}`;
+    this._localStorageKeyDocs = `earthstar:documents:pathandauthor:${workspace}`;
+
+    let existingData = localStorage.getItem(this._localStorageKeyDocs);
+
+    if (existingData !== null) {
+      let parsed = JSON.parse(existingData);
+
+      if (!isSerializedDriverDocs(parsed)) {
+        return;
+      }
+
+      this.docByPathAndAuthor = parsed.byPathAndAuthor;
+      this.docsByPathNewestFirst = parsed.byPathNewestFirst;
+    }
+  }
+
+  async getConfig(key: string): Promise<string | undefined> {
+    key = `${this._localStorageKeyConfig}:${key}`;
+    let result = localStorage.getItem(key);
+    return result === null ? undefined : result;
+  }
+  
+  async setConfig(key: string, value: string): Promise<void> {
+    super.setConfig(key, value);
+
+    key = `${this._localStorageKeyConfig}:${key}`;
+    localStorage.setItem(key, value);
+  }
+
+  async deleteConfig(key: string): Promise<boolean> {
+    let had = super.deleteConfig(key);
+    
+    key = `${this._localStorageKeyConfig}:${key}`;
+    localStorage.removeItem(key);
+    
+    return had;
+  }
+
+  async upsert(doc: Doc): Promise<Doc> {
+    let upsertedDoc = super.upsert(doc);
+
+    const docsToBeSerialised: SerializedDriverDocs = {
+      byPathAndAuthor: this.docByPathAndAuthor,
+      byPathNewestFirst: this.docsByPathNewestFirst,
+    };
+
+    // Todo: Debouncing of writing in-memory values to localStorage.
+    localStorage.setItem(
+      this._localStorageKeyDocs,
+      JSON.stringify(docsToBeSerialised)
+    );
+
+    return upsertedDoc;
+  }
+}

--- a/src/test/browser/platform.browser.ts
+++ b/src/test/browser/platform.browser.ts
@@ -8,6 +8,7 @@ import {
     cryptoDrivers_universal,
     storageDriversAsync_universal,
 } from '../universal/platform.universal';
+import { StorageDriverLocalStorage } from '../../storage/storage-driver-local-storage';
 
 //================================================================================
 
@@ -16,6 +17,7 @@ export let cryptoDrivers_browserOnly: ICryptoDriver[] = [
 ];
 
 export let storageDriversAsync_browserOnly: ClassThatImplements<IStorageDriverAsync>[] = [
+    StorageDriverLocalStorage
 ];
 
 //================================================================================


### PR DESCRIPTION
## What's the problem you solved?

This PR adds a storage driver which uses LocalStorage to persist docs and configs. Making a driver feels really straightforward and elegant!

## What _didn't_ you solve?

- The persisting of docs to LocalStorage happens on every single `upsert`. No debouncing yet.
- I was delighted (but not surprised 😄) to see that there was a way to simply add my driver to `test/browser/platform.browser.ts`. But I don't think this tests that my driver is actually persisting between sessions. I'd love your guidance on how to add this test to the suite
