### PR TITLE
Storage invariants & lock adjustments

### DIFF
--- a/src/query-follower/query-follower-types.ts
+++ b/src/query-follower/query-follower-types.ts
@@ -10,6 +10,9 @@ import {
 
 export type QueryFollowerEvent = 'close' | 'caught-up';
 
+/**
+ * @deprecated - replaced with StorageAsync.liveQuery()
+ */
 export interface IQueryFollower {
     storage: IStorageAsync;
 

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -33,6 +33,9 @@ let logger = new Logger('QueryFollower', 'redBright');
 
 //================================================================================
 
+/**
+ * @deprecated - replaced with StorageAsync.liveQuery()
+ */
 export class QueryFollower implements IQueryFollower {
     storage: IStorageAsync;
     bus: Superbus<QueryFollowerEvent>;

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -102,7 +102,7 @@ export class QueryFollower implements IQueryFollower {
 
             let { doc, maxLocalIndex, prevDocFromSameAuthor, prevLatestDoc, docIsLatest } = ingestEvent;
 
-            logger.debug(`on storage 'ingest' event.  doc._locaIndex: ${doc._localIndex}; overall maxLocalIndex: ${maxLocalIndex}`);
+            logger.debug(`on storage 'ingest' event.  doc._localIndex: ${doc._localIndex}; overall maxLocalIndex: ${maxLocalIndex}; channel: ${channel}`);
             if (this.isClosed()) { logger.debug(`stopping catch-up because we're closed`); return; }
 
             let docIsInteresting = docMatchesFilter(doc, this._query.filter ?? {});

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -69,7 +69,7 @@ export class QueryFollower implements IQueryFollower {
 
         // enforce rules on supported queries
         if (this._query.historyMode !== 'all') { throw new NotImplementedError(`query historyMode must be 'all'`); }
-        if (this._query.orderBy !== 'localIndex ASC') { throw new NotImplementedError(`query orderBy must be 'localIndexASC'`); }
+        if (this._query.orderBy !== 'localIndex ASC') { throw new NotImplementedError(`query orderBy must be 'localIndex ASC'`); }
         if (this._query.limit !== undefined) { throw new NotImplementedError(`query must not have a limit`); }
 
         // startAfter is equivalent to maxLocalIndex -- both are the max known value, not the next one that we want (+1)

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -198,11 +198,6 @@ export class StorageAsync implements IStorageAsync {
         return docs[0];
     }
 
-    async queryWithState(query: Query = {}): Promise<QueryResult> {
-        logger.debug(`queryWithState`, query);
-        return await this.storageDriver.queryWithState(query);
-    }
-
     async queryDocs(query: Query = {}): Promise<Doc[]> {
         logger.debug(`queryDocs`, query);
         return await this.storageDriver.queryDocs(query);

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -122,6 +122,14 @@ export class StorageAsync implements IStorageAsync {
         this.bus.sendLater('didClose');
         logger.debug('...closing done');
     }
+    async destroy(): Promise<void> {
+        logger.debug('destroying...');
+        logger.debug('    destroying: close()...');
+        await this.close();
+        logger.debug('    destroying: driver.destroy()...');
+        await this.storageDriver.destroy();
+        logger.debug('...destroying done');
+    }
 
     //--------------------------------------------------
     // CONFIG

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -24,6 +24,7 @@ import {
     IngestResultAndDoc,
     StorageEvent,
     StorageId,
+    QueryResult,
 } from './storage-types';
 import {
     IFormatValidator,
@@ -176,6 +177,11 @@ export class StorageAsync implements IStorageAsync {
         });
         if (docs.length === 0) { return undefined; }
         return docs[0];
+    }
+
+    async queryWithState(query: Query = {}): Promise<QueryResult> {
+        logger.debug(`queryWithState`, query);
+        return await this.storageDriver.queryWithState(query);
     }
 
     async queryDocs(query: Query = {}): Promise<Doc[]> {

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -352,7 +352,7 @@ export class StorageAsync implements IStorageAsync {
         loggerIngest.debug(' >> ingest: ...done running protected region');
 
         loggerIngest.debug('...send ingest event after releasing the lock');
-        await this.bus.sendAndWait('ingest', ingestEvent);
+        await this.bus.sendAndWait(`ingest|${docToIngest.path}` as 'ingest', ingestEvent); // include the path in the channel even on failures
 
         return ingestEvent;
     }

--- a/src/storage/storage-driver-async-memory.ts
+++ b/src/storage/storage-driver-async-memory.ts
@@ -86,8 +86,17 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
         return this._isClosed;
     }
     async close(): Promise<void> {
-        logger.debug('closing');
+        logger.debug('close');
         this._isClosed = true;
+    }
+    async destroy(): Promise<void> {
+        logger.debug('destroy');
+        await this.close();
+        // this is an in-memory store so we don't really need to delete anything,
+        // but this might help free up memory for the garbage collector
+        this._configKv = {};
+        this.docsByPathNewestFirst.clear();
+        this.docByPathAndAuthor.clear();
     }
 
     //--------------------------------------------------

--- a/src/storage/storage-driver-async-memory.ts
+++ b/src/storage/storage-driver-async-memory.ts
@@ -133,9 +133,8 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
         return docs;
     }
 
-    async queryWithState(queryToClean: Query): Promise<QueryResult> {
+    async queryDocs(queryToClean: Query): Promise<Doc[]> {
         // Query the documents.
-        let maxLocalIndexBefore = this.getMaxLocalIndex();
 
         logger.debug('queryDocs', queryToClean);
         if (this._isClosed) { throw new StorageIsClosedError(); }
@@ -144,12 +143,7 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
         let { query, willMatch } = cleanUpQuery(queryToClean);
         logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
         if (willMatch === 'nothing') {
-            return {
-                docs: [],
-                maxLocalIndexBefore,
-                maxLocalIndexAfter: maxLocalIndexBefore,  // same maxLocalIndex before and after; no time has passed
-                maxLocalIndexInResult: -1,
-            };
+            return []
         }
 
         // get history docs or all docs
@@ -214,20 +208,8 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
             }
         }
 
-        let maxLocalIndexInResult: number = docs.reduce((maxSoFar: number, doc: Doc) => {
-            return Math.max(maxSoFar, doc._localIndex ?? -1)
-        }, -1);
-        let maxLocalIndexAfter = this.getMaxLocalIndex();
-        logger.debug(`    queryDocs is done: found ${filteredDocs.length} docs.  max localIndexInResult = ${maxLocalIndexInResult}; max overall local index between ${maxLocalIndexBefore} and ${maxLocalIndexAfter}`);
-        return {
-            docs: filteredDocs,
-            maxLocalIndexBefore,
-            maxLocalIndexAfter,
-            maxLocalIndexInResult,
-        };
-    }
-    async queryDocs(queryToClean: Query): Promise<Doc[]> {
-        return (await this.queryWithState(queryToClean)).docs;
+        logger.debug(`    queryDocs is done: found ${filteredDocs.length} docs.`);
+        return filteredDocs;
     }
   
     //--------------------------------------------------

--- a/src/storage/storage-driver-async-memory.ts
+++ b/src/storage/storage-driver-async-memory.ts
@@ -1,8 +1,4 @@
 import {
-    Lock
-} from 'concurrency-friends';
-
-import {
     Cmp
 } from './util-types';
 import {
@@ -15,7 +11,8 @@ import {
     Query
 } from "../query/query-types";
 import {
-    IStorageDriverAsync, QueryResult
+    IStorageDriverAsync,
+    QueryResult,
 } from "./storage-types";
 import {
     StorageIsClosedError,
@@ -67,7 +64,6 @@ let docComparePathDESCthenNewestFirst = (a: Doc, b: Doc): Cmp => {
 
 export class StorageDriverAsyncMemory implements IStorageDriverAsync {
     workspace: WorkspaceAddress;
-    lock: Lock<any>;
     _maxLocalIndex: LocalIndex = -1;  // when empty, the max is -1.  when one item is present, starting with index 0, the max is 0
     _isClosed: boolean = false;
     _configKv: Record<string, string> = {};
@@ -81,7 +77,6 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
     constructor(workspace: WorkspaceAddress) {
         logger.debug('constructor');
         this.workspace = workspace;
-        this.lock = new Lock();
     }
   
     //--------------------------------------------------
@@ -232,7 +227,6 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
         this._maxLocalIndex += 1;  // this starts at -1 initially, so the first doc has a localIndex of 0.
         doc._localIndex = this._maxLocalIndex;
         Object.freeze(doc);
-
         logger.debug('upsert', doc);
   
         // save into our various indexes and data structures
@@ -240,7 +234,7 @@ export class StorageDriverAsyncMemory implements IStorageDriverAsync {
         this.docByPathAndAuthor.set(combinePathAndAuthor(doc), doc);
 
         // get list of history docs at this path
-        let docsByPath = this.docsByPathNewestFirst.get(doc.path) || [];
+        let docsByPath = this.docsByPathNewestFirst.get(doc.path) ?? [];
         // remove existing doc from same author same path
         docsByPath = docsByPath.filter(d => d.author !== doc.author);
         // add this new doc

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -34,11 +34,19 @@ export type StorageBusChannel =
 export interface QueryResult {
     // the docs from the query...
     docs: Doc[],
-    // ...and the storageDriver's maxLocalIndex at the time the
-    // query was done.  This is the OVERALL max local index for
-    // the whole storage, not just for the resulting docs.
-    // TODO: include the max for the doc results also
-    maxLocalIndex: number,
+    // ...and the storageDriver's maxLocalIndex at the time
+    // just before and just after the query was done.
+    // This provided a lower and upper bound for the maxLocalIndex
+    // associated with the resulting docs.
+    // (This is the OVERALL max local index for
+    // the whole storage, not just for the resulting docs.)
+    maxLocalIndexBefore: number,
+    maxLocalIndexAfter: number,
+    // The max localIndex out of the returned docs.
+    // This could be much smaller than the overall maxLocalIndex
+    // if the docs have been filtered.
+    // If there are no matching docs, this is -1.
+    maxLocalIndexInResult: number,
 }
 
 // IngestEvents are returned from storage.set() and storage.ingest(),

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -166,7 +166,6 @@ export interface IStorageAsync extends IStorageAsyncConfigStorage {
     getAllDocsAtPath(path: Path): Promise<Doc[]>;
     getLatestDocAtPath(path: Path): Promise<Doc | undefined>;
 
-    queryWithState(query: Query): Promise<QueryResult>;
     queryDocs(query?: Query): Promise<Doc[]>;
 
     liveQuery(query: Query, cb: (event: LiveQueryEvent) => Promise<void>): Promise<Thunk>;  // unsub
@@ -213,7 +212,6 @@ export interface IStorageDriverAsync extends IStorageAsyncConfigStorage {
     getMaxLocalIndex(): number;
 
     // these should return frozen docs
-    queryWithState(query: Query): Promise<QueryResult>;
     queryDocs(query: Query): Promise<Doc[]>;
 //    queryPaths(query: Query): Doc[];
 

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -153,6 +153,13 @@ export interface IStorageAsync extends IStorageAsyncConfigStorage {
      */
     close(): Promise<void>;
 
+    /**
+     * Actually delete and forget data locally.
+     * This also closes if it's not closed already.
+     * This can be called again with no effect.
+     */
+    destroy(): Promise<void>;
+
     //--------------------------------------------------
     // GET
 
@@ -201,6 +208,13 @@ export interface IStorageDriverAsync extends IStorageAsyncConfigStorage {
     isClosed(): boolean;
     // the IStorage will call this
     close(): Promise<void>;
+
+    /**
+     * Actually delete and forget data locally.
+     * This also closes if it's not closed already.
+     * This can be called again with no effect.
+     */
+    destroy(): Promise<void>;
 
     //--------------------------------------------------
     // GET

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -33,6 +33,11 @@ export type StorageEvent =
     'ingest' |  // 'ingest|/some/path.txt'
     'willClose' | 'didClose';
 
+export interface QueryResult {
+    docs: Doc[],
+    maxLocalIndex: number,
+}
+
 export interface IStorageAsyncConfig {
     // This is for local storage of configuration details for storage instances.
     // This data will not be directly sync'd with other instances.
@@ -83,6 +88,7 @@ export interface IStorageAsync extends IStorageAsyncConfig {
     getAllDocsAtPath(path: Path): Promise<Doc[]>;
     getLatestDocAtPath(path: Path): Promise<Doc | undefined>;
 
+    queryWithState(query: Query): Promise<QueryResult>;
     queryDocs(query?: Query): Promise<Doc[]>;
 //    queryPaths(query?: Query): Path[];
 //    queryAuthors(query?: Query): AuthorAddress[];
@@ -126,7 +132,8 @@ export interface IStorageDriverAsync extends IStorageAsyncConfig {
     // load it once at startup and then keep it in memory.
     getMaxLocalIndex(): number;
 
-    // this should return frozen docs
+    // these should return frozen docs
+    queryWithState(query: Query): Promise<QueryResult>;
     queryDocs(query: Query): Promise<Doc[]>;
 //    queryPaths(query: Query): Doc[];
 

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -79,7 +79,7 @@ export interface IngestEventSuccess {
     // note this is actually still the latest doc if the just-written doc is an older one (docIsLatest===false)
     prevLatestDoc: Doc | null,
 }
-export interface IngestEventExisting {
+export interface DocAlreadyExists {
     // for a doc that was previously ingested, when a live query is catching up.
     kind: 'existing',
     maxLocalIndex: number,
@@ -109,7 +109,7 @@ export type IngestEvent =
 
 export type LiveQueryEvent =
     IngestEvent |
-    IngestEventExisting |
+    DocAlreadyExists |
     StorageEventWillClose |
     StorageEventDidClose;
 

--- a/src/test/shared-test-code/storage-async.shared.ts
+++ b/src/test/shared-test-code/storage-async.shared.ts
@@ -163,6 +163,38 @@ export let runStorageTests = (subtestName: string, makeStorage: (ws: WorkspaceAd
         t.end();
     });
 
+    t.test(SUBTEST_NAME + ': storage destroy() should also close()', async (t: any) => {
+        let initialCryptoDriver = GlobalCryptoDriver;
+
+        let workspace = '+gardening.abcde';
+        let storage = makeStorage(workspace);
+
+        t.same(typeof storage.storageId, 'string', 'storage has a storageId');
+
+        t.same(storage.isClosed(), false, 'is not initially closed');
+        await doesNotThrow(t, async () => storage.isClosed(), 'isClosed does not throw');
+
+        loggerTest.debug('destroying...');
+        await storage.destroy();
+        loggerTest.debug('...done destroying');
+
+        // wait for didClose to happen on setTimeout
+        await sleep(20);
+
+        t.same(storage.isClosed(), true, 'is closed after close()');
+        await doesNotThrow(t, async () => storage.isClosed(), 'isClosed does not throw');
+
+        await doesNotThrow(t, async () => await storage.close(), 'can close() twice');
+        t.same(storage.isClosed(), true, 'still closed after calling close() twice');
+
+        await doesNotThrow(t, async () => await storage.destroy(), 'can destroy() twice');
+        t.same(storage.isClosed(), true, 'still closed after calling destroy() twice');
+
+        // storage is already closed
+        t.same(initialCryptoDriver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  started as ${(initialCryptoDriver as any).name}, ended as ${(GlobalCryptoDriver as any).name}`)
+        t.end();
+    });
+
     t.test(SUBTEST_NAME + ': storage overwriteAllDocsByAuthor', async (t: any) => {
         let initialCryptoDriver = GlobalCryptoDriver;
 

--- a/src/test/shared-test-code/storage-driver-async.shared.ts
+++ b/src/test/shared-test-code/storage-driver-async.shared.ts
@@ -41,7 +41,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': empty storage', async (t: any) => {
+    t.test(SUBTEST_NAME + ': empty storage, close', async (t: any) => {
         let initialCryptoDriver = GlobalCryptoDriver;
 
         let workspace = '+gardening.abcde';
@@ -51,6 +51,24 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
         t.same(await driver.queryDocs({}), [], 'query returns empty array');
 
         await driver.close();
+        t.same(driver.isClosed(), true, 'isClosed');
+
+        t.same(initialCryptoDriver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  started as ${(initialCryptoDriver as any).name}, ended as ${(GlobalCryptoDriver as any).name}`)
+        t.end();
+    });
+
+    t.test(SUBTEST_NAME + ': destroy', async (t: any) => {
+        let initialCryptoDriver = GlobalCryptoDriver;
+
+        let workspace = '+gardening.abcde';
+        let driver = makeDriver(workspace);
+
+        t.same(driver.getMaxLocalIndex(), -1, 'maxLocalIndex starts at -1');
+        t.same(await driver.queryDocs({}), [], 'query returns empty array');
+
+        await driver.destroy();
+        t.same(driver.isClosed(), true, 'isClosed');
+
         t.same(initialCryptoDriver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  started as ${(initialCryptoDriver as any).name}, ended as ${(GlobalCryptoDriver as any).name}`)
         t.end();
     });

--- a/src/test/shared-test-code/storage-driver-async.shared.ts
+++ b/src/test/shared-test-code/storage-driver-async.shared.ts
@@ -134,7 +134,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
 
         let docResult: Doc = await driver.upsert(doc0);
         t.same(docResult._localIndex, 0, 'upsert doc0, localIndex is now 0');
-        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._locaIndex');
+        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._localIndex');
 
         let docs = await driver.queryDocs({});
         t.same(docs.length, 1, 'query returns 1 doc');
@@ -146,7 +146,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
         // overwrite same author, latest
         docResult = await driver.upsert(doc1);
         t.same(docResult._localIndex, 1, 'upsert doc1 from same author, localIndex is now 1');
-        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._locaIndex');
+        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._localIndex');
 
         docs = await driver.queryDocs({});
         t.same(docs.length, 1, 'query returns 1 doc');
@@ -158,7 +158,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
         // add a second author, latest
         docResult = await driver.upsert(doc2);
         t.same(docResult._localIndex, 2, 'upsert doc2 from second author, localIndex is now 3');
-        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._locaIndex');
+        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._localIndex');
 
         let latestDocs = await driver.queryDocs({ historyMode: 'latest' });
         t.same(latestDocs.length, 1, 'there is 1 latest doc');
@@ -176,7 +176,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
         // -- should not bounce, that's the job of IStorage
         docResult = await driver.upsert(doc3);
         t.same(docResult._localIndex, 3, 'upsert doc3 from second author (but older), localIndex is now 3');
-        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._locaIndex');
+        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._localIndex');
 
         // latest doc is now from author 1
         latestDocs = await driver.queryDocs({ historyMode: 'latest' });
@@ -194,7 +194,7 @@ export let runStorageDriverTests = (driverName: string, makeDriver: (ws: Workspa
         // add a third author, oldest
         docResult = await driver.upsert(doc4);
         t.same(docResult._localIndex, 4, 'upsert doc4 from new third author (but oldest), localIndex is now 5');
-        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._locaIndex');
+        t.same(driver.getMaxLocalIndex(), docResult._localIndex, 'driver.getMaxLocalIndex() matches doc._localIndex');
 
         // latest doc is still from author 1
         latestDocs = await driver.queryDocs({ historyMode: 'latest' });


### PR DESCRIPTION
Trying to be more careful with the storage invariants (maxLocalIndex)...

## Code changes

### queryWithState

* Storage and StorageDriver have a new method `queryWithState` which returns a list of docs AND the driver's maxLocalIndex at the time of querying.  This will help the queryFollower be more rigorous with its behavior, but I haven't fixed up queryFollower yet.

(When querying is slow, we will want to know the maxLocalIndex **at the time the query was done** so we can reason correctly about the results.)

Querying is always safe to do in parallel, especially with this change (above), so there's no lock involved here.

### Lock and ingest changes

* There's a new type, `IngestEvent`
* `Storage.ingest` returns an IngestEvent and also sends it out as an event on the bus.
* The lock covers less code now

We do a lot of read-modify-write, which will result in corrupted state if several threads are doing it at the same time.  So `Storage.set` and `Storage.ingest` needed to happen in a lock so only one copy could run at once.  `Storage.set` calls `Storage.ingest`, and also `Storage.ingest` can be called by itself.  This made the lock code complex since it could be entered in different ways.

I've made the locked area smaller - now it's just the middle portion of `Storage.ingest` which also includes the call to `StorageDriver.upsert`.

We are inefficiently hitting the storageDriver 4 times but only need to do it 2 times:
* ...1. in `storage.set`, get existing docs so we can choose a higher timestamp for the new doc we're writing
* ...2. in `storage.ingest`, get existing docs **again**, so we can emit a richer WriteEvent with context about what was there before
* ...3. in `driver.upsert`, get existing docs **again,** so we can emit a richer WriteEvent with context about what was there before
* ...4. in `driver.upsert`, write the doc (and update _maxLocalIndex)

1 is now outside the lock, which is ok, and 2/3/4 are inside the lock, which is needed for safety.

Eventually we should restructure this code to re-use that query we keep doing 3 times.  That would mean passing those existing docs as a parameter into `StorageDriver.upsert` (avoiding step 3 above).  We could also make the lock cover `set` again, and pass those existing docs from there down into `ingest` (avoiding step 2 above).  This would all make the code more complex so I'm skipping it for now.

## Questions

At the end we send a WriteEvent on the Storage bus.  Should the happen inside or outside of the lock?

For now, it's outside.

(If it happens in the lock, you could cause a deadlock if you tried to write a document from inside an event handler.)

## Diagram

After applying this PR:

(except note that on the bottom right, we're not yet passing the existingDocsSamePath into driver.upsert, we're querying it again instead.)

![set-and-ingest](https://user-images.githubusercontent.com/32660718/119897744-bc478200-bef5-11eb-8d91-15ca83c83d6d.png)

## The invariants we have to follow

### doc._localIndex

Each doc in a StorageDriver is given a `_localIndex` integer when it is upserted.  This number starts at 0 for the first doc and increases by 1 for each additional doc.  It never decreases.

This is similar to the index number of a message in a Scuttlebutt log -- it's the order that this storageDriver received them.  This order is specific to this storageDriver (which is why it's called the LOCAL index).

This is the sort order of docs that we use when syncing.  We start syncing linearly at _localIndex 0 and increase from there.  We can resume syncing where we left off without the possibility of missing a document, and we only have to remember one piece of state about our syncing progress (the _localIndex of the last doc we got).

When a doc is overwritten with a new version, the new version gets a new higher _localIndex and the old version goes away, leaving a gap in the sequence.  The gap is OK.  Similarly, when ephemeral docs expire and go away, they leave gaps in the sequence.

A doc's _localIndex will never change once assigned, in this storageDriver.  When we send it to another peer, we send the _localIndex with it so the other peer knows its syncing progress with us... but then that peer stores the doc and, as a result, gives it a new _localIndex specific to itself.

The _localIndex is an ["extra field"](https://earthstar-docs.netlify.app/docs/reference/earthstar-specification/#extra-fields-for-syncing) according to the spec.  It's not included in the doc's signature so peers are free to change it when they receive docs.

If peers try to cause trouble by sending weird values, they will only mess up their own syncing state with other peers; they can't cause damage that will spread.

### driver._maxLocalIndex

StorageDriver maintains a variable `_maxLocalIndex`.  This needs to always be set to the maximum value of `doc._localIndex` for all docs in the storage.  We keep it in a variable in memory for quick synchronous access.
* _maxLocalIndex is an integer >= -1.
* At startup, we need to compute _maxLocalIndex by scanning all the docs in the storage, or by loading it if it was previously saved in the config storage area.
* _maxLocalIndex starts at -1 when the storage is empty.
* _maxLocalIndex must increase by 1 with every `upsert`.
* _maxLocalIndex must never decrease.
* No two docs can ever have the same _localIndex.
* _maxLocalIndex should ideally be equal to the max of all doc._localIndex for the whole workspace storage.  It is allowed to be greater than this as a result of incomplete transactions (see below), but must never be less than this, or you can end up with two docs with the same _localIndex.
* When writing a doc, _maxLocalIndex must be changed at the same time as the doc is written, atomically.
    * If you can't do that, update _maxLocalIndex first, then write the doc as a second transaction.  If interrupted you might end up with _maxLocalIndex that's one too high (the corresponding doc was not saved).  That is OK.

## The algorithm

This follows the rules above.
```
when a new storageDriver starts up:
    get the lock
    if storage is empty:
        driver._maxLocalIndex = -1
    else:
        driver._maxLocalIndex = max(doc._localIndex) over all docs in this workspace
        or, driver._maxLocalIndex = load("_maxLocalIndex")  // if we saved it before
    release the lock

when upserting a document to a storageDriver,
    get the lock
    driver._maxLocalIndex += 1
    doc._localIndex = driver._maxLocalindex
    // ideally persist them both in one atomic write transaction, but if you can't, do this:
    persist(driver._maxLocalIndex)
    persist(doc)
    release the lock
```