### PR TITLE
Add StorageDriverIndexedDb

### DIFF
--- a/src/entries/browser.ts
+++ b/src/entries/browser.ts
@@ -1,1 +1,2 @@
 export { StorageDriverLocalStorage} from '../storage/storage-driver-local-storage'
+export { StorageDriverIndexedDB } from '../storage/storage-driver-indexeddb'

--- a/src/storage/storage-driver-indexeddb.ts
+++ b/src/storage/storage-driver-indexeddb.ts
@@ -1,0 +1,266 @@
+import { Doc, WorkspaceAddress } from "../util/doc-types";
+import { StorageIsClosedError } from "../util/errors";
+import { StorageDriverAsyncMemory } from "./storage-driver-async-memory";
+
+//--------------------------------------------------
+
+import { Logger } from "../util/log";
+let logger = new Logger("storage driver indexeddb", "yellowBright");
+
+//================================================================================
+
+const DOC_STORE = "documents";
+const DOCUMENTS_ID = "allDocs";
+const CONFIG_STORE = "config";
+
+export class StorageDriverIndexedDB extends StorageDriverAsyncMemory {
+  _db: IDBDatabase | null = null;
+
+  constructor(workspace: WorkspaceAddress) {
+    super(workspace);
+    logger.debug("constructor");
+
+    this.docByPathAndAuthor = new Map();
+    this.docsByPathNewestFirst = new Map();
+  }
+
+  async getIndexedDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      if (this._db) {
+        return resolve(this._db);
+      }
+
+      const request = window.indexedDB.open(
+        `stonesoup:database:${this.workspace}`,
+        1
+      );
+
+      request.onerror = () => {
+        logger.error(`Could not open IndexedDB for ${this.workspace}`);
+        logger.error(request.error);
+      };
+
+      request.onupgradeneeded = function () {
+        const db = request.result;
+
+        // we're going to store everything in one row.
+        db.createObjectStore(DOC_STORE, { keyPath: "id" });
+        db.createObjectStore(CONFIG_STORE, { keyPath: "key" });
+      };
+
+      request.onsuccess = () => {
+        this._db = request.result;
+
+        const transaction = this._db.transaction([DOC_STORE], "readonly");
+
+        const store = transaction.objectStore(DOC_STORE);
+        const retrieval = store.get(DOCUMENTS_ID);
+
+        retrieval.onsuccess = () => {
+          const docs = retrieval.result;
+
+          if (!docs) {
+            return resolve(request.result);
+          }
+
+          this.docByPathAndAuthor = new Map(
+            Object.entries(docs.byPathAndAuthor)
+          );
+          this.docsByPathNewestFirst = new Map(
+            Object.entries(docs.byPathNewestFirst)
+          );
+
+          return resolve(request.result);
+        };
+
+        retrieval.onerror = () => {
+          logger.debug(
+            `StorageIndexedDB constructing: No existing DB for ${this.workspace}`
+          );
+          reject();
+        };
+      };
+    });
+  }
+
+  //--------------------------------------------------
+  // LIFECYCLE
+
+  // isClosed(): inherited
+  async close(erase: boolean): Promise<void> {
+    logger.debug("close");
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    if (erase) {
+      logger.debug("...close: and erase");
+      this._configKv = {};
+      this._maxLocalIndex = -1;
+      this.docsByPathNewestFirst.clear();
+      this.docByPathAndAuthor.clear();
+
+      logger.debug("...close: erasing indexeddb");
+
+      const db = await this.getIndexedDb();
+
+      for (let key of await this.listConfigKeys()) {
+        await this.deleteConfig(key);
+      }
+
+      const deletion = db
+        .transaction(DOC_STORE, "readwrite")
+        .objectStore(DOC_STORE)
+        .delete(DOCUMENTS_ID);
+
+      deletion.onsuccess = () => {
+        logger.debug("...close: erasing is done");
+      };
+    }
+    this._isClosed = true;
+    logger.debug("...close is done.");
+  }
+
+  //--------------------------------------------------
+  // CONFIG
+
+  async getConfig(key: string): Promise<string | undefined> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    const db = await this.getIndexedDb();
+
+    return new Promise((resolve, reject) => {
+      const retrieval = db
+        .transaction(CONFIG_STORE, "readonly")
+        .objectStore(CONFIG_STORE)
+        .get(key);
+
+      retrieval.onsuccess = () => {
+        if (!retrieval.result) {
+          return resolve(undefined);
+        }
+
+        return resolve(retrieval.result.value);
+      };
+
+      retrieval.onerror = () => {
+        reject(retrieval.error);
+      };
+    });
+  }
+  async setConfig(key: string, value: string): Promise<void> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    const db = await this.getIndexedDb();
+
+    return new Promise((resolve, reject) => {
+      const set = db
+        .transaction(CONFIG_STORE, "readwrite")
+        .objectStore(CONFIG_STORE)
+        .put({ key, value });
+
+      set.onsuccess = () => {
+        resolve();
+      };
+
+      set.onerror = () => {
+        reject();
+      };
+    });
+  }
+  async listConfigKeys(): Promise<string[]> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    const db = await this.getIndexedDb();
+
+    return new Promise((resolve, reject) => {
+      const getKeys = db
+        .transaction(CONFIG_STORE, "readonly")
+        .objectStore(CONFIG_STORE)
+        .getAllKeys();
+
+      getKeys.onsuccess = () => {
+        resolve(getKeys.result.sort() as string[]);
+      };
+
+      getKeys.onerror = () => {
+        reject();
+      };
+    });
+  }
+
+  async deleteConfig(key: string): Promise<boolean> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    const db = await this.getIndexedDb();
+
+    const hadIt = (await this.getConfig(key)) !== undefined;
+
+    return new Promise((resolve, reject) => {
+      const deletion = db
+        .transaction(CONFIG_STORE, "readwrite")
+        .objectStore(CONFIG_STORE)
+        .delete(key);
+
+      deletion.onsuccess = () => {
+        resolve(hadIt);
+      };
+
+      deletion.onerror = () => {
+        reject();
+      };
+    });
+  }
+
+  //--------------------------------------------------
+  // GET
+
+  // getMaxLocalIndex(): inherited
+  // queryDocs(query: Query): inherited
+
+  //--------------------------------------------------
+  // SET
+
+  async upsert(doc: Doc): Promise<Doc> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    let upsertedDoc = await super.upsert(doc);
+
+    // After every upsert, for now, we save everything
+    // to IndexedDB as a single giant blob.
+    // TODO: debounce this, only do it every 1 second or something
+
+    const docs = {
+      byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
+      byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
+    };
+
+    const db = await this.getIndexedDb();
+
+    return new Promise((resolve, reject) => {
+      const put = db
+        .transaction(DOC_STORE, "readwrite")
+        .objectStore(DOC_STORE)
+        .put({
+          id: DOCUMENTS_ID,
+          docs,
+        });
+
+      put.onsuccess = () => {
+        resolve(upsertedDoc);
+      };
+
+      put.onerror = () => {
+        reject();
+      };
+    });
+  }
+}

--- a/src/storage/storage-driver-local-storage.ts
+++ b/src/storage/storage-driver-local-storage.ts
@@ -121,7 +121,7 @@ export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
         return this._setConfigSync(key, value);
     }
     async listConfigKeys(): Promise<string[]> {
-        return await this._listConfigKeysSync();
+        return this._listConfigKeysSync();
     }
     async deleteConfig(key: string): Promise<boolean> {
         return this._deleteConfigSync(key);

--- a/src/test/improved/test-scenarios.browser.ts
+++ b/src/test/improved/test-scenarios.browser.ts
@@ -7,6 +7,7 @@ import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
 import { CryptoDriverChloride } from '../../crypto/crypto-driver-chloride';
 import { StorageDriverAsyncMemory } from '../../storage/storage-driver-async-memory';
 import { StorageDriverLocalStorage } from '../../storage/storage-driver-local-storage';
+import { StorageDriverIndexedDB } from '../../storage/storage-driver-indexeddb'
 
 // test types
 import { TestScenario } from './test-scenario-types';
@@ -37,6 +38,14 @@ export let testScenarios: TestScenario[] = [
         platforms: { browser: true, node: false, deno: false },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverLocalStorage(ws),
+    },
+    {
+        name: 'StorageDriverIndexedDB + CryptoDriverTweetnacl',
+        cryptoDriver: CryptoDriverTweetnacl,
+        persistent: true,
+        platforms: { browser: true, node: false, deno: false },
+        makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
+            new StorageDriverIndexedDB(ws),
     }
 ]
 


### PR DESCRIPTION
## What's the problem you solved?

This adds a very basic version of a storage driver that persists to IndexedDB. 5mb localstorage shackles be gone!

## What solution are you recommending?

Upon the first usage of the storage, docs are hydrated into memory from a _single_ IndexedDB row. Every time the storage upserts a doc, it writes all docs in memory back into that single row. I told you it was basic!

We do this because reading and writing stuff to IndexedDB is very slow. But this isn't an approach that'll last because of the aforementioned 'loads the whole space into memory' thing.

The storage config is stored inside of a separate object store, and works more or less as you would normally use IndexedDB.

