### PR TITLE
Asynchronous ICrypto + noble/ed25519 driver

### DIFF
--- a/benchmark-results/benchmark.browser.txt
+++ b/benchmark-results/benchmark.browser.txt
@@ -1,23 +1,30 @@
 $ cat browserify-tests/bundle.benchmark.js | browser-run
-2021-05-24T21:33:45.055Z
+2021-12-08T11:14:56.222Z
 
 > CryptoDriverChloride (without waiting)
   > ops/sec
-  >     105,433:  sha256
-  >         206:  generateAuthorKeypair
-  >         179:  sign
-  >       5,887:  validate
+  >     153,454:  sha256
+  >         372:  generateAuthorKeypair
+  >      14,731:  sign
+  >       7,621:  validate
 
 > CryptoDriverChloride (after waiting)
   > ops/sec
-  >     112,948:  sha256
-  >       4,428:  generateAuthorKeypair
-  >      11,281:  sign
-  >       6,040:  validate
+  >     154,878:  sha256
+  >       6,947:  generateAuthorKeypair
+  >      14,926:  sign
+  >       7,703:  validate
 
 > CryptoDriverTweetnacl 
   > ops/sec
-  >     184,236:  sha256
-  >         214:  generateAuthorKeypair
-  >         213:  sign
-  >         115:  validate
+  >     242,970:  sha256
+  >         394:  generateAuthorKeypair
+  >         388:  sign
+  >         196:  validate
+
+> CryptoDriverNoble 
+  > ops/sec
+  >     244,218:  sha256
+  >       2,506:  generateAuthorKeypair
+  >       1,751:  sign
+  >         473:  validate

--- a/benchmark-results/benchmark.node.txt
+++ b/benchmark-results/benchmark.node.txt
@@ -1,55 +1,55 @@
-2021-05-24T21:34:18.683Z
+2021-12-08T10:40:10.594Z
 
 > CryptoDriverFake 
   > ops/sec
-  >     372,660:  sha256
-  >     414,504:  generateAuthorKeypair
-  >     441,870:  sign
-  >   5,788,501:  validate
+  >     463,142:  sha256
+  >     642,947:  generateAuthorKeypair
+  >     597,745:  sign
+  >   4,902,151:  validate
 
 > CryptoDriverNode 
   > ops/sec
-  >     166,475:  sha256
-  >      18,266:  generateAuthorKeypair
-  >      10,462:  sign
-  >       7,964:  validate
+  >     246,058:  sha256
+  >      27,594:  generateAuthorKeypair
+  >      15,872:  sign
+  >      10,147:  validate
 
 > CryptoDriverTweetnacl 
   > ops/sec
-  >     286,496:  sha256
-  >         223:  generateAuthorKeypair
-  >         228:  sign
-  >         115:  validate
+  >     356,144:  sha256
+  >         388:  generateAuthorKeypair
+  >         382:  sign
+  >         194:  validate
 
 > StorageDriverAsyncMemory w/ CryptoDriverFake
   > ops/sec
-  >       2,632:  add 100 docs (docs/sec)
-  >       2,632:  sync 100 docs to empty storage (docs/sec)
-  >       3,846:  sync 100 docs again to full storage (docs/sec)
+  >       3,030:  add 100 docs (docs/sec)
+  >       3,226:  sync 100 docs to empty storage (docs/sec)
+  >       3,448:  sync 100 docs again to full storage (docs/sec)
 
-  >       3,497:  add 500 docs (docs/sec)
-  >       2,976:  sync 500 docs to empty storage (docs/sec)
-  >       3,067:  sync 500 docs again to full storage (docs/sec)
+  >       4,098:  add 500 docs (docs/sec)
+  >       3,378:  sync 500 docs to empty storage (docs/sec)
+  >       3,247:  sync 500 docs again to full storage (docs/sec)
 
 
 > StorageDriverAsyncMemory w/ CryptoDriverNode
   > ops/sec
-  >       1,852:  add 100 docs (docs/sec)
-  >       1,667:  sync 100 docs to empty storage (docs/sec)
-  >       1,724:  sync 100 docs again to full storage (docs/sec)
+  >       2,222:  add 100 docs (docs/sec)
+  >       1,786:  sync 100 docs to empty storage (docs/sec)
+  >       1,961:  sync 100 docs again to full storage (docs/sec)
 
-  >       1,786:  add 500 docs (docs/sec)
-  >       1,506:  sync 500 docs to empty storage (docs/sec)
-  >       1,493:  sync 500 docs again to full storage (docs/sec)
+  >       2,262:  add 500 docs (docs/sec)
+  >       1,792:  sync 500 docs to empty storage (docs/sec)
+  >       1,818:  sync 500 docs again to full storage (docs/sec)
 
 
 > StorageDriverAsyncMemory w/ CryptoDriverTweetnacl
   > ops/sec
-  >          74:  add 100 docs (docs/sec)
-  >          57:  sync 100 docs to empty storage (docs/sec)
-  >          56:  sync 100 docs again to full storage (docs/sec)
+  >         123:  add 100 docs (docs/sec)
+  >          94:  sync 100 docs to empty storage (docs/sec)
+  >          95:  sync 100 docs again to full storage (docs/sec)
 
-  >          75:  add 500 docs (docs/sec)
-  >          56:  sync 500 docs to empty storage (docs/sec)
-  >          56:  sync 500 docs again to full storage (docs/sec)
+  >         111:  add 500 docs (docs/sec)
+  >          89:  sync 500 docs to empty storage (docs/sec)
+  >          92:  sync 500 docs again to full storage (docs/sec)
 

--- a/benchmark-results/benchmark.node.txt
+++ b/benchmark-results/benchmark.node.txt
@@ -1,55 +1,73 @@
-2021-12-08T10:40:10.594Z
+2021-12-08T11:13:51.869Z
 
 > CryptoDriverFake 
   > ops/sec
-  >     463,142:  sha256
-  >     642,947:  generateAuthorKeypair
-  >     597,745:  sign
-  >   4,902,151:  validate
+  >     437,519:  sha256
+  >     595,523:  generateAuthorKeypair
+  >     587,440:  sign
+  >   5,080,820:  validate
 
 > CryptoDriverNode 
   > ops/sec
-  >     246,058:  sha256
-  >      27,594:  generateAuthorKeypair
-  >      15,872:  sign
-  >      10,147:  validate
+  >     263,524:  sha256
+  >      28,674:  generateAuthorKeypair
+  >      14,158:  sign
+  >      10,194:  validate
 
 > CryptoDriverTweetnacl 
   > ops/sec
-  >     356,144:  sha256
-  >         388:  generateAuthorKeypair
-  >         382:  sign
-  >         194:  validate
+  >     368,428:  sha256
+  >         393:  generateAuthorKeypair
+  >         394:  sign
+  >         201:  validate
+
+> CryptoDriverNoble 
+  > ops/sec
+  >     368,091:  sha256
+  >       3,215:  generateAuthorKeypair
+  >       2,271:  sign
+  >         517:  validate
 
 > StorageDriverAsyncMemory w/ CryptoDriverFake
   > ops/sec
-  >       3,030:  add 100 docs (docs/sec)
-  >       3,226:  sync 100 docs to empty storage (docs/sec)
-  >       3,448:  sync 100 docs again to full storage (docs/sec)
+  >       3,125:  add 100 docs (docs/sec)
+  >       3,448:  sync 100 docs to empty storage (docs/sec)
+  >       4,167:  sync 100 docs again to full storage (docs/sec)
 
-  >       4,098:  add 500 docs (docs/sec)
-  >       3,378:  sync 500 docs to empty storage (docs/sec)
-  >       3,247:  sync 500 docs again to full storage (docs/sec)
+  >       4,237:  add 500 docs (docs/sec)
+  >       3,571:  sync 500 docs to empty storage (docs/sec)
+  >       3,497:  sync 500 docs again to full storage (docs/sec)
 
 
 > StorageDriverAsyncMemory w/ CryptoDriverNode
   > ops/sec
-  >       2,222:  add 100 docs (docs/sec)
-  >       1,786:  sync 100 docs to empty storage (docs/sec)
-  >       1,961:  sync 100 docs again to full storage (docs/sec)
+  >       2,381:  add 100 docs (docs/sec)
+  >       2,041:  sync 100 docs to empty storage (docs/sec)
+  >       2,083:  sync 100 docs again to full storage (docs/sec)
 
-  >       2,262:  add 500 docs (docs/sec)
-  >       1,792:  sync 500 docs to empty storage (docs/sec)
-  >       1,818:  sync 500 docs again to full storage (docs/sec)
+  >       2,381:  add 500 docs (docs/sec)
+  >       1,748:  sync 500 docs to empty storage (docs/sec)
+  >       1,866:  sync 500 docs again to full storage (docs/sec)
 
 
 > StorageDriverAsyncMemory w/ CryptoDriverTweetnacl
   > ops/sec
-  >         123:  add 100 docs (docs/sec)
-  >          94:  sync 100 docs to empty storage (docs/sec)
+  >         125:  add 100 docs (docs/sec)
+  >          95:  sync 100 docs to empty storage (docs/sec)
   >          95:  sync 100 docs again to full storage (docs/sec)
 
-  >         111:  add 500 docs (docs/sec)
+  >         123:  add 500 docs (docs/sec)
   >          89:  sync 500 docs to empty storage (docs/sec)
-  >          92:  sync 500 docs again to full storage (docs/sec)
+  >          94:  sync 500 docs again to full storage (docs/sec)
+
+
+> StorageDriverAsyncMemory w/ CryptoDriverNoble
+  > ops/sec
+  >         368:  add 100 docs (docs/sec)
+  >         233:  sync 100 docs to empty storage (docs/sec)
+  >         240:  sync 100 docs again to full storage (docs/sec)
+
+  >         376:  add 500 docs (docs/sec)
+  >         224:  sync 500 docs to empty storage (docs/sec)
+  >         232:  sync 500 docs again to full storage (docs/sec)
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@noble/ed25519": "^1.3.0",
     "chalk": "^4.1.1",
     "chloride": "^2.4.1",
     "concurrency-friends": "^5.0.1",

--- a/src/crypto/crypto-driver-chloride.ts
+++ b/src/crypto/crypto-driver-chloride.ts
@@ -36,13 +36,13 @@ export let waitUntilChlorideIsReady = async () => {
  * Works in the browser.
  */
 export const CryptoDriverChloride: ICryptoDriver = class {
-    static sha256(input: string | Uint8Array): Uint8Array {
+    static async sha256(input: string | Uint8Array): Promise<Uint8Array> {
         if (typeof input === 'string') { input = stringToBuffer(input); }
         if (identifyBufOrBytes(input) === 'bytes') { input = bytesToBuffer(input); }
         let resultBuf = sodium.crypto_hash_sha256(input);
         return bufferToBytes(resultBuf);
     }
-    static generateKeypairBytes(seed?: Uint8Array): KeypairBytes {
+    static async generateKeypairBytes(seed?: Uint8Array): Promise<KeypairBytes> {
         // If provided, the seed is used as the secret key.
         // If omitted, a random secret key is generated.
         logger.debug('generateKeypairBytes');
@@ -59,7 +59,7 @@ export const CryptoDriverChloride: ICryptoDriver = class {
             secret: bufferToBytes((keys.privateKey || keys.secretKey).slice(0, 32)),
         };
     };
-    static sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Uint8Array {
+    static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
         logger.debug('sign');
         let secretBuf = bytesToBuffer(concatBytes(keypairBytes.secret, keypairBytes.pubkey));
         if (typeof msg === 'string') { msg = stringToBuffer(msg); }
@@ -69,7 +69,7 @@ export const CryptoDriverChloride: ICryptoDriver = class {
             sodium.crypto_sign_detached(msg, secretBuf)
         );
     }
-    static verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): boolean {
+    static async verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean> {
         logger.debug('verify');
         try {
             if (typeof msg === 'string') { msg = stringToBuffer(msg); }

--- a/src/crypto/crypto-driver-fake.ts
+++ b/src/crypto/crypto-driver-fake.ts
@@ -23,21 +23,21 @@ let logger = new Logger('crypto-driver-fake', 'cyan');
  * DO NOT use this in production.
  */
 export const CryptoDriverFake: ICryptoDriver = class {
-    static sha256(input: string | Uint8Array): Uint8Array {
+    static async sha256(input: string | Uint8Array): Promise<Uint8Array> {
         return base32StringToBytes('bwnu6vkidepzqwaoww6yvhdhsyhd5elkvrjp5wqdktaupuxziuvxa');
     }
-    static generateKeypairBytes(): KeypairBytes {
+    static async generateKeypairBytes(): Promise<KeypairBytes> {
         logger.debug('generateKeypairBytes (FAKE)');
         return {
             pubkey: base32StringToBytes('b3utxcw7aiebdyue2gcx44uiqmxbsm2tc45deglh4s2jyonvgfvja'),
             secret: base32StringToBytes('bwnu6vkidepzqwaoww6yvhdhsyhd5elkvrjp5wqdktaupuxziuvxa'),
         };
     };
-    static sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Uint8Array {
+    static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
         logger.debug('sign (FAKE)');
         return base32StringToBytes('bjljalsg2mulkut56anrteaejvrrtnjlrwfvswiqsi2psero22qqw7am34z3u3xcw7nx6mha42isfuzae5xda3armky5clrqrewrhgca');
     }
-    static verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): boolean {
+    static async verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean> {
         logger.debug('verify (FAKE)');
         return true;
     }

--- a/src/crypto/crypto-driver-noble.ts
+++ b/src/crypto/crypto-driver-noble.ts
@@ -1,0 +1,56 @@
+import * as ed from '@noble/ed25519';
+import {
+    ICryptoDriver,
+    KeypairBytes,
+} from './crypto-types';
+import {
+    concatBytes,   
+    stringToBytes
+} from '../util/bytes';
+import { createHash } from 'sha256-uint8array';
+
+//--------------------------------------------------
+
+import { Logger } from '../util/log';
+let logger = new Logger('crypto-driver-noble', 'cyan');
+
+//================================================================================
+/**
+ * A verison of the ILowLevelCrypto interface backed by noble/ed25519.
+ * Works in the browser.
+ */
+export const CryptoDriverNoble: ICryptoDriver = class {
+    static async sha256(input: string | Uint8Array): Promise<Uint8Array> {
+        if (typeof input === 'string') {
+            return createHash('sha256').update(input, 'utf-8').digest()
+        } else {
+            return createHash('sha256').update(input).digest()
+        }
+    }
+    static async generateKeypairBytes(): Promise<KeypairBytes> {
+        logger.debug('generateKeypairBytes');
+        let secret = ed.utils.randomPrivateKey();
+        let pubkey = await ed.getPublicKey(secret);
+        
+        return {
+            pubkey,
+            secret,
+        };
+    };
+    static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
+        logger.debug('sign');
+        let secret = concatBytes(keypairBytes.secret, keypairBytes.pubkey);
+        if (typeof msg === 'string') { msg = stringToBytes(msg); }
+        return ed.sign(msg, keypairBytes.secret);
+    }
+    static async verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean> {
+        logger.debug('verify');
+        try {
+            if (typeof msg === 'string') { msg = stringToBytes(msg); }
+            return ed.verify(sig, msg, publicKey);
+        } catch (e) {
+            /* istanbul ignore next */
+            return false;
+        }
+    }
+};

--- a/src/crypto/crypto-driver-noble.ts
+++ b/src/crypto/crypto-driver-noble.ts
@@ -39,7 +39,6 @@ export const CryptoDriverNoble: ICryptoDriver = class {
     };
     static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
         logger.debug('sign');
-        let secret = concatBytes(keypairBytes.secret, keypairBytes.pubkey);
         if (typeof msg === 'string') { msg = stringToBytes(msg); }
         return ed.sign(msg, keypairBytes.secret);
     }
@@ -47,7 +46,8 @@ export const CryptoDriverNoble: ICryptoDriver = class {
         logger.debug('verify');
         try {
             if (typeof msg === 'string') { msg = stringToBytes(msg); }
-            return ed.verify(sig, msg, publicKey);
+            const result = await ed.verify(sig, msg, publicKey);            
+            return result;
         } catch (e) {
             /* istanbul ignore next */
             return false;

--- a/src/crypto/crypto-driver-node.ts
+++ b/src/crypto/crypto-driver-node.ts
@@ -65,16 +65,16 @@ let _lengthenDerSecret = (b: Uint8Array): Uint8Array =>
  * Does not work in the browser.
  */
 export const CryptoDriverNode: ICryptoDriver = class {
-    static sha256(input: string | Uint8Array): Uint8Array {
+    static async sha256(input: string | Uint8Array): Promise<Uint8Array> {
         return bufferToBytes(
             crypto.createHash('sha256').update(input).digest()
         );
     }
-    static generateKeypairBytes(): KeypairBytes {
+    static async generateKeypairBytes(): Promise<KeypairBytes> {
         logger.debug('generateKeypairBytes');
         return _shortenDer(_generateKeypairDerBytes());
     };
-    static sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Uint8Array {
+    static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
         logger.debug('sign');
         if (typeof msg === 'string') { msg = stringToBuffer(msg); }
         return bufferToBytes(crypto.sign(
@@ -87,7 +87,7 @@ export const CryptoDriverNode: ICryptoDriver = class {
             }
         ));
     }
-    static verify(publicKey: Uint8Array, sig: Uint8Array, msg: string | Uint8Array): boolean {
+    static async verify(publicKey: Uint8Array, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean> {
         logger.debug('verif');
         // TODO: convert uint8arrays to Buffers?
         if (typeof msg === 'string') { msg = stringToBuffer(msg); }

--- a/src/crypto/crypto-driver-tweetnacl.ts
+++ b/src/crypto/crypto-driver-tweetnacl.ts
@@ -20,14 +20,14 @@ let logger = new Logger('crypto-driver-tweetnacl', 'cyan');
  * Works in the browser.
  */
 export const CryptoDriverTweetnacl: ICryptoDriver = class {
-    static sha256(input: string | Uint8Array): Uint8Array {
+    static async sha256(input: string | Uint8Array): Promise<Uint8Array> {
         if (typeof input === 'string') {
             return createHash('sha256').update(input, 'utf-8').digest()
         } else {
             return createHash('sha256').update(input).digest()
         }
     }
-    static generateKeypairBytes(): KeypairBytes {
+    static async generateKeypairBytes(): Promise<KeypairBytes> {
         logger.debug('generateKeypairBytes');
         let keys = tweetnacl.sign.keyPair();
         return {
@@ -35,13 +35,13 @@ export const CryptoDriverTweetnacl: ICryptoDriver = class {
             secret: (keys.secretKey).slice(0, 32),
         };
     };
-    static sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Uint8Array {
+    static async sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array> {
         logger.debug('sign');
         let secret = concatBytes(keypairBytes.secret, keypairBytes.pubkey);
         if (typeof msg === 'string') { msg = stringToBytes(msg); }
         return tweetnacl.sign.detached(msg, secret);
     }
-    static verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): boolean {
+    static async verify(publicKey: Buffer, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean> {
         logger.debug('verify');
         try {
             if (typeof msg === 'string') { msg = stringToBytes(msg); }

--- a/src/crypto/crypto-types.ts
+++ b/src/crypto/crypto-types.ts
@@ -17,11 +17,11 @@ export interface KeypairBytes {
  * These all handle base32-encoded strings.
  */
 export interface ICrypto {
-    sha256base32(input: string | Uint8Array): Base32String;
-    generateAuthorKeypair(name: string): AuthorKeypair | ValidationError;
-    sign(keypair: AuthorKeypair, msg: string | Uint8Array): Base32String | ValidationError;
-    verify(authorAddress: AuthorAddress, sig: Base32String, msg: string | Uint8Array): boolean;
-    checkAuthorKeypairIsValid(keypair: AuthorKeypair): true | ValidationError;
+    sha256base32(input: string | Uint8Array): Promise<Base32String>;
+    generateAuthorKeypair(name: string): Promise<AuthorKeypair | ValidationError>;
+    sign(keypair: AuthorKeypair, msg: string | Uint8Array): Promise<Base32String | ValidationError>;
+    verify(authorAddress: AuthorAddress, sig: Base32String, msg: string | Uint8Array): Promise<boolean>;
+    checkAuthorKeypairIsValid(keypair: AuthorKeypair): Promise<true | ValidationError>;
 }
 
 /**
@@ -31,8 +31,8 @@ export interface ICrypto {
  * These all handle Uint8Arrays (bytes)
  */
 export interface ICryptoDriver {
-    sha256(input: string | Uint8Array): Uint8Array;
-    generateKeypairBytes(): KeypairBytes;
-    sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Uint8Array;
-    verify(publicKey: Uint8Array, sig: Uint8Array, msg: string | Uint8Array): boolean;
+    sha256(input: string | Uint8Array): Promise<Uint8Array>;
+    generateKeypairBytes(): Promise<KeypairBytes>;
+    sign(keypairBytes: KeypairBytes, msg: string | Uint8Array): Promise<Uint8Array>;
+    verify(publicKey: Uint8Array, sig: Uint8Array, msg: string | Uint8Array): Promise<boolean>;
 }

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -39,8 +39,10 @@ export const Crypto: ICrypto = class {
     /**
      * Do a sha256 hash, then return the output bytes encoded as base32.
      */
-    static sha256base32(input: string | Uint8Array): Base32String {
-        return base32BytesToString(GlobalCryptoDriver.sha256(input));
+    static async sha256base32(input: string | Uint8Array): Promise<Base32String> {
+        const b32 = await GlobalCryptoDriver.sha256(input)
+        
+        return base32BytesToString(b32);
     }
 
     /**
@@ -53,9 +55,9 @@ export const Crypto: ICrypto = class {
      * 
      * @param name A 4-character nickname to make the address easier to remember and identify.
      */
-    static generateAuthorKeypair(name: string): AuthorKeypair | ValidationError {
+    static async generateAuthorKeypair(name: string): Promise<AuthorKeypair | ValidationError> {
         logger.debug(`generateAuthorKeypair("${name}")`);
-        let keypairBytes: KeypairBytes = GlobalCryptoDriver.generateKeypairBytes();
+        let keypairBytes: KeypairBytes = await GlobalCryptoDriver.generateKeypairBytes();
         let keypairFormatted = {
             address: assembleAuthorAddress(name, base32BytesToString(keypairBytes.pubkey)),
             secret: base32BytesToString(keypairBytes.secret),
@@ -73,12 +75,15 @@ export const Crypto: ICrypto = class {
      * Can return a ValidationError if the keypair is bad
      * or something goes unexpectedly wrong with signing.
      */
-    static sign(keypair: AuthorKeypair, msg: string | Uint8Array): Base32String | ValidationError {
+    static async sign(keypair: AuthorKeypair, msg: string | Uint8Array): Promise<Base32String | ValidationError> {
         logger.debug(`sign`);
         try {
             let keypairBytes = decodeAuthorKeypairToBytes(keypair);
             if (isErr(keypairBytes)) { return keypairBytes; }
-            return base32BytesToString(GlobalCryptoDriver.sign(keypairBytes, msg));
+            
+            const signed = await GlobalCryptoDriver.sign(keypairBytes, msg)
+            
+            return base32BytesToString(signed);
         } catch (err: any) {
             /* istanbul ignore next */
             return new ValidationError('unexpected error while signing: ' + err.message);
@@ -94,7 +99,7 @@ export const Crypto: ICrypto = class {
      *   * signature base32 format is valid but signature itself is invalid
      *   * unexpected failure from crypto library
      */
-    static verify(authorAddress: AuthorAddress, sig: Base32String, msg: string | Uint8Array): boolean {
+    static async verify(authorAddress: AuthorAddress, sig: Base32String, msg: string | Uint8Array): Promise<boolean> {
         logger.debug(`verify`);
         try {
             let authorParsed = parseAuthorAddress(authorAddress);
@@ -116,7 +121,7 @@ export const Crypto: ICrypto = class {
      * - a ValidationError if the author address or secret are not validly formatted strings.
      * - a ValidationError if anything else goes wrong
      */
-    static checkAuthorKeypairIsValid(keypair: AuthorKeypair): true | ValidationError {
+    static async checkAuthorKeypairIsValid(keypair: AuthorKeypair): Promise<true | ValidationError> {
         // We check if the secret matches the pubkey by signing something and then validating the signature.
         // However, key generation is deterministic, so it would be more direct to just do this:
         //
@@ -134,10 +139,10 @@ export const Crypto: ICrypto = class {
             if (isErr(addressErr)) { return addressErr; }
 
             let msg = 'a test message to sign. ' + randomId();
-            let sig = this.sign(keypair, msg);
+            let sig = await this.sign(keypair, msg);
             if (isErr(sig)) { return sig; }
 
-            let isValid = this.verify(keypair.address, sig, msg);
+            let isValid = await this.verify(keypair.address, sig, msg);
             if (isValid === false) { return new ValidationError('pubkey does not match secret'); }
 
             return true;

--- a/src/crypto/global-crypto-driver.ts
+++ b/src/crypto/global-crypto-driver.ts
@@ -1,4 +1,4 @@
-import { CryptoDriverTweetnacl } from './crypto-driver-tweetnacl';
+import { CryptoDriverNoble } from './crypto-driver-noble';
 import { ICryptoDriver } from './crypto-types';
 
 //--------------------------------------------------
@@ -8,7 +8,7 @@ let logger = new Logger('crypto', 'cyanBright');
 
 //================================================================================
 
-export let GlobalCryptoDriver: ICryptoDriver = CryptoDriverTweetnacl;
+export let GlobalCryptoDriver: ICryptoDriver = CryptoDriverNoble;
 
 export let setGlobalCryptoDriver = (driver: ICryptoDriver): void => {
     logger.debug(`set global crypto driver: ${(driver as any).name}`);

--- a/src/example-app.ts
+++ b/src/example-app.ts
@@ -68,7 +68,7 @@ let main = async () => {
     peer.addStorage(storage);
 
     loggerMain.info('generate a keypair')
-    let keypair = Crypto.generateAuthorKeypair('suzy');
+    let keypair = await Crypto.generateAuthorKeypair('suzy');
     if (isErr(keypair)) {
         console.error(keypair);
         process.exit(1);

--- a/src/format-validators/format-validator-types.ts
+++ b/src/format-validators/format-validator-types.ts
@@ -26,7 +26,7 @@ export interface IFormatValidator {
     format: FormatName;
 
     /** Deterministic hash of this version of the document */
-    hashDocument(doc: Doc): Base32String | ValidationError;
+    hashDocument(doc: Doc): Promise<Base32String | ValidationError>;
 
     /**
      * Add an author signature to the document.
@@ -34,7 +34,7 @@ export interface IFormatValidator {
      * it will be overwritten here, so you may as well just set signature: '' on the input.
      * Return a copy of the original document with the signature field changed, or return a ValidationError.
      */
-    signDocument(keypair: AuthorKeypair, doc: Doc): Doc | ValidationError;
+    signDocument(keypair: AuthorKeypair, doc: Doc): Promise<Doc | ValidationError>;
 
     /**
      * Return a copy of the doc without extra fields, plus the extra fields
@@ -58,8 +58,8 @@ export interface IFormatValidator {
     _checkAuthorCanWriteToPath(author: AuthorAddress, path: Path): true | ValidationError;
     _checkTimestampIsOk(timestamp: number, deleteAfter: number | null, now: number): true | ValidationError;
     _checkPathIsValid(path: Path, deleteAfter?: number | null): true | ValidationError;
-    _checkAuthorSignatureIsValid(doc: Doc): true | ValidationError;
-    _checkContentMatchesHash(content: string, contentHash: Base32String): true | ValidationError;
+    _checkAuthorSignatureIsValid(doc: Doc): Promise<true | ValidationError>;
+    _checkContentMatchesHash(content: string, contentHash: Base32String): Promise<true | ValidationError>;
 
     // TODO: add these methods for building addresses
     // and remove them from crypto.ts and encoding.ts

--- a/src/peer/peer-client.ts
+++ b/src/peer/peer-client.ts
@@ -120,7 +120,7 @@ export class PeerClient implements IPeerClient {
         let serverSaltedSet = new Set<string>(saltedWorkspaces);
         let commonWorkspaceSet = new Set<WorkspaceAddress>();
         for (let plainWs of this.peer.workspaces()) {
-            let saltedWs = saltAndHashWorkspace(salt, plainWs);
+            let saltedWs = await saltAndHashWorkspace(salt, plainWs);
             if (serverSaltedSet.has(saltedWs)) {
                 commonWorkspaceSet.add(plainWs);
             }

--- a/src/peer/peer-server.ts
+++ b/src/peer/peer-server.ts
@@ -42,8 +42,8 @@ export class PeerServer implements IPeerServer {
         // request is empty and unused
         loggerServe.debug('serve_saltyHandshake...');
         let salt = randomId();
-        let saltedWorkspaces = this.peer.workspaces().map(ws =>
-            saltAndHashWorkspace(salt, ws));
+        let saltedWorkspaces = await Promise.all(this.peer.workspaces().map(ws =>
+             saltAndHashWorkspace(salt, ws)));
         loggerServe.debug(`...serve_saltyHandshake is done.  found ${saltedWorkspaces.length} workspaces.`);
         return {
             serverPeerId: this.peer.peerId,

--- a/src/peer/peer-types.ts
+++ b/src/peer/peer-types.ts
@@ -70,8 +70,8 @@ export interface IPeer {
  */
 
 // ok this isn't a type, but I put it here anyway since it's shared code for client and server
-export let saltAndHashWorkspace = (salt: string, workspace: WorkspaceAddress): string =>
-    Crypto.sha256base32(salt + workspace + salt);
+export let saltAndHashWorkspace = async (salt: string, workspace: WorkspaceAddress): Promise<string> =>
+   await Crypto.sha256base32(salt + workspace + salt);
 
 //--------------------------------------------------
 // SALTY HANDSHAKE

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -237,7 +237,7 @@ export class StorageAsync implements IStorageAsync {
             format: 'es.4',
             author: keypair.address,
             content: docToSet.content,
-            contentHash: Crypto.sha256base32(docToSet.content),
+            contentHash: await Crypto.sha256base32(docToSet.content),
             deleteAfter: docToSet.deleteAfter ?? null,
             path: docToSet.path,
             timestamp,
@@ -247,7 +247,7 @@ export class StorageAsync implements IStorageAsync {
         }
 
         loggerSet.debug('...signing doc');
-        let signedDoc = this.formatValidator.signDocument(keypair, doc);
+        let signedDoc = await this.formatValidator.signDocument(keypair, doc);
         if (isErr(signedDoc)) {
             return {
                 kind: 'failure',
@@ -396,13 +396,13 @@ export class StorageAsync implements IStorageAsync {
             let emptyDoc: Doc = {
                 ...cleanedDoc,
                 content: '',
-                contentHash: Crypto.sha256base32(''),
+                contentHash: await Crypto.sha256base32(''),
                 timestamp: doc.timestamp + 1,
                 signature: '?',
             }
 
             // sign and ingest it
-            let signedDoc = this.formatValidator.signDocument(keypair, emptyDoc)
+            let signedDoc = await this.formatValidator.signDocument(keypair, emptyDoc)
             if (isErr(signedDoc)) { return signedDoc }
 
             let ingestEvent = await this.ingest(signedDoc);

--- a/src/storage/storage-cache.ts
+++ b/src/storage/storage-cache.ts
@@ -99,6 +99,12 @@ export class StorageCache {
     this._storage = storage;
     this._timeToLive = timeToLive || 1000;
   }
+  
+  // SET - just pass along to the backing storage
+  
+  set(keypair: AuthorKeypair, docToSet: DocToSet) {
+    return this._storage.set(keypair, docToSet)
+  }
 
   // GET
 

--- a/src/storage/storage-cache.ts
+++ b/src/storage/storage-cache.ts
@@ -175,7 +175,7 @@ export class StorageCache {
             docs,
             expires: Date.now() + this._timeToLive,
           });
-          logger.debug("⌛️");
+          
           this._fireOnCacheUpdateds();
         });
       }
@@ -189,8 +189,8 @@ export class StorageCache {
     );
     follower.bus.on(async (event: LiveQueryEvent) => {
       if (event.kind === 'existing' || event.kind === 'success') {
-          logger.debug("🐣");
-          this._updateCacheOptimistically(event.doc);
+          
+          this._updateCache(event.doc);
       }
     });
 
@@ -210,7 +210,7 @@ export class StorageCache {
         docs,
         expires: Date.now() + this._timeToLive,
       });
-      logger.debug("👹");
+      
       this._fireOnCacheUpdateds();
     });
 
@@ -218,54 +218,7 @@ export class StorageCache {
     return [];
   }
 
-  // SET
-
-  // Do a version of set which assumes this will be latest, and add that doc to the cache.
-  // In the meantime, call set on the backing storage, and update results after.
-  set(keypair: AuthorKeypair, docToSet: DocToSet): IngestEvent {
-    if (this._storage.isClosed()) {
-      throw new StorageIsClosedError();
-    }
-
-    let doc: Doc = {
-      format: "es.4",
-      author: keypair.address,
-      content: docToSet.content,
-      contentHash: Crypto.sha256base32(docToSet.content),
-      deleteAfter: null,
-      path: docToSet.path,
-      timestamp: microsecondNow(),
-      workspace: this._storage.workspace,
-      signature: "?",
-    };
-
-    let signedDoc = this._storage.formatValidator.signDocument(keypair, doc);
-    if (isErr(signedDoc)) {
-      return {
-          kind: 'failure',
-          reason: 'invalid_document',
-          err: signedDoc,
-          maxLocalIndex: this._storage.storageDriver.getMaxLocalIndex(),
-      }
-    }
-
-    // Update the cache optimistically
-    logger.debug("🚂");
-    this._updateCacheOptimistically(signedDoc);
-
-    // Set with actual storage.
-    this._storage.set(keypair, docToSet);
-
-    // Assume this is accepted and latest for the moment.
-    return {
-        kind: 'success',
-        maxLocalIndex: this._storage.storageDriver.getMaxLocalIndex(),
-        doc: signedDoc,  // this is missing _localIndex for now
-        docIsLatest: true,
-        prevDocFromSameAuthor: null, // we don't actually know this
-        prevLatestDoc: null, // we don't actually know this
-    };
-  }
+  
 
   // OVERWRITE
   
@@ -281,7 +234,7 @@ export class StorageCache {
   // CACHE
 
   // Update cache entries as best as we can until results from the backing storage arrive.
-  _updateCacheOptimistically(doc: Doc): void {
+  _updateCache(doc: Doc): void {
     this._docCache.forEach((entry, key) => {
       const query: Query = JSON.parse(key);
 
@@ -313,7 +266,7 @@ export class StorageCache {
      */
 
       const appendDoc = () => {
-        logger.debug("🥞");
+        
         let nextDocs = [...entry.docs, doc];
         this._docCache.set(key, {
           ...entry,
@@ -323,7 +276,7 @@ export class StorageCache {
       };
 
       const replaceDoc = ({ exact }: { exact: boolean }) => {
-        logger.debug("🔄");
+        
         const nextDocs = entry.docs.map((existingDoc) => {
           if (
             exact &&
@@ -372,7 +325,7 @@ export class StorageCache {
           return;
         }
 
-        logger.debug("🕰");
+        
         replaceDoc({ exact: true });
         return;
       }
@@ -387,7 +340,7 @@ export class StorageCache {
       const docIsLater = doc.timestamp > latestDoc.timestamp;
 
       if (docIsDifferent && docIsLater) {
-        logger.debug("⌚️");
+        
         replaceDoc({ exact: false });
         return;
       }

--- a/src/storage/storage-driver-local-storage.ts
+++ b/src/storage/storage-driver-local-storage.ts
@@ -121,7 +121,7 @@ export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
         return this._setConfigSync(key, value);
     }
     async listConfigKeys(): Promise<string[]> {
-        return await this._listConfigKeysSync();
+        return this._listConfigKeysSync();
     }
     async deleteConfig(key: string): Promise<boolean> {
         return this._deleteConfigSync(key);

--- a/src/test/improved/query-follower.shared.ts
+++ b/src/test/improved/query-follower.shared.ts
@@ -91,8 +91,8 @@ export let runQueryFollowerTests = (scenario: TestScenario) => {
         let workspace = '+gardening.abcde';
         let storage = makeStorage(workspace);
 
-        let keypair1 = Crypto.generateAuthorKeypair('aaaa');
-        let keypair2 = Crypto.generateAuthorKeypair('bbbb');
+        let keypair1 = await Crypto.generateAuthorKeypair('aaaa');
+        let keypair2 = await Crypto.generateAuthorKeypair('bbbb');
         if (isErr(keypair1) || isErr(keypair2)) {
             t.ok(false, 'error making keypair');
             t.end();
@@ -248,8 +248,8 @@ export let runQueryFollowerTests = (scenario: TestScenario) => {
         let workspace = '+gardening.abcde';
         let storage = makeStorage(workspace);
 
-        let keypair1 = Crypto.generateAuthorKeypair('aaaa');
-        let keypair2 = Crypto.generateAuthorKeypair('bbbb');
+        let keypair1 = await Crypto.generateAuthorKeypair('aaaa');
+        let keypair2 = await Crypto.generateAuthorKeypair('bbbb');
         if (isErr(keypair1) || isErr(keypair2)) {
             t.ok(false, 'error making keypair');
             t.end();

--- a/src/test/improved/storage-async.shared.ts
+++ b/src/test/improved/storage-async.shared.ts
@@ -125,8 +125,8 @@ export let runStorageAsyncTests = (scenario: TestScenario) => {
         let workspace = '+gardening.abcde';
         let storage = makeStorage(workspace);
 
-        let keypair1 = Crypto.generateAuthorKeypair('aaaa');
-        let keypair2 = Crypto.generateAuthorKeypair('bbbb');
+        let keypair1 = await Crypto.generateAuthorKeypair('aaaa');
+        let keypair2 = await Crypto.generateAuthorKeypair('bbbb');
         if (isErr(keypair1) || isErr(keypair2)) {
             t.ok(false, 'error making keypair');
             t.end();

--- a/src/test/node/platform.node.ts
+++ b/src/test/node/platform.node.ts
@@ -4,6 +4,7 @@ import { IStorageDriverAsync } from '../../storage/storage-types';
 
 import { CryptoDriverNode } from '../../crypto/crypto-driver-node';
 
+
 import {
     cryptoDrivers_universal,
     storageDriversAsync_universal,

--- a/src/test/shared-benchmark-code/crypto-driver-benchmark.shared.ts
+++ b/src/test/shared-benchmark-code/crypto-driver-benchmark.shared.ts
@@ -20,31 +20,31 @@ export let runCryptoDriverBenchmark = async (runner: BenchmarkRunner, cryptoDriv
     //==================================================
     // setup
 
-    let keypairBytes = cryptoDriver.generateKeypairBytes() as KeypairBytes;
+    let keypairBytes = await cryptoDriver.generateKeypairBytes() as KeypairBytes;
     if (isErr(keypairBytes)) { console.warn(keypairBytes); }
 
     let msgToSign = 'hello' + randomId() + randomId();
-    let sigBytes = cryptoDriver.sign(keypairBytes, msgToSign);
+    let sigBytes = await cryptoDriver.sign(keypairBytes, msgToSign);
 
     //==================================================
     // benchmarks
 
     await runner.runMany('sha256', {minDuration: 1234}, async () => {
         let msgToHash = 'hello' + randomId() + randomId();
-        cryptoDriver.sha256(msgToHash);
+        await cryptoDriver.sha256(msgToHash);
     });
 
     await runner.runMany('generateAuthorKeypair', {minDuration: 1234}, async () => {
-        let thisKeypair = cryptoDriver.generateKeypairBytes();
+        let thisKeypair = await cryptoDriver.generateKeypairBytes();
         if (isErr(thisKeypair)) { console.warn(thisKeypair); }
     });
 
     await runner.runMany('sign', {minDuration: 1234}, async () => {
-        cryptoDriver.sign(keypairBytes, msgToSign);
+        await cryptoDriver.sign(keypairBytes, msgToSign);
     });
 
     await runner.runMany('validate', {minDuration: 1234}, async () => {
-        cryptoDriver.verify(keypairBytes.pubkey, sigBytes, msgToSign);
+        await cryptoDriver.verify(keypairBytes.pubkey, sigBytes, msgToSign);
     });
 
     //==================================================

--- a/src/test/shared-benchmark-code/storage-driver-benchmark.shared.ts
+++ b/src/test/shared-benchmark-code/storage-driver-benchmark.shared.ts
@@ -36,9 +36,9 @@ export let runStorageDriverBenchmark = async (runner: BenchmarkRunner, cryptoDri
     let workspace = '+gardening.pals';
     let validator = FormatValidatorEs4;
 
-    let keypair1 = Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
-    let keypair2 = Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
-    let keypair3 = Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
+    let keypair1 = await Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
+    let keypair2 = await Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
+    let keypair3 = await Crypto.generateAuthorKeypair('aaaa') as AuthorKeypair;
 
     //==================================================
     // benchmarks

--- a/src/test/shared-test-code/crypto-driver-interop.shared.ts
+++ b/src/test/shared-test-code/crypto-driver-interop.shared.ts
@@ -21,13 +21,13 @@ export let runCryptoDriverInteropTests = (drivers: ICryptoDriver[]) => {
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': compare sigs from each driver', (t: any) => {
+    t.test(SUBTEST_NAME + ': compare sigs from each driver', async (t: any) => {
         let msg = 'hello';
-        let keypairBytes: KeypairBytes = drivers[0].generateKeypairBytes();
+        let keypairBytes: KeypairBytes = await drivers[0].generateKeypairBytes();
         let keypairName = (drivers[0] as any).name;
         let sigs: { name: string, sig: Uint8Array }[] = [];
         for (let signer of drivers) {
-            let sig = signer.sign(keypairBytes, msg);
+            let sig = await signer.sign(keypairBytes, msg);
             t.same(identifyBufOrBytes(sig), 'bytes', 'signature is bytes, not buffer');
             sigs.push({ name: (signer as any).name, sig });
         }
@@ -39,11 +39,11 @@ export let runCryptoDriverInteropTests = (drivers: ICryptoDriver[]) => {
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': sign with one driver, verify with another', (t: any) => {
+    t.test(SUBTEST_NAME + ': sign with one driver, verify with another', async (t: any) => {
         let msg = 'hello';
         for (let signer of drivers) {
-            let keypairBytes: KeypairBytes = drivers[0].generateKeypairBytes();
-            let sig = signer.sign(keypairBytes, msg);
+            let keypairBytes: KeypairBytes = await drivers[0].generateKeypairBytes();
+            let sig = await signer.sign(keypairBytes, msg);
             let signerName = (signer as any).name;
             for (let verifier of drivers) {
                 let verifierName = (verifier as any).name;

--- a/src/test/shared-test-code/crypto-driver.shared.ts
+++ b/src/test/shared-test-code/crypto-driver.shared.ts
@@ -29,7 +29,7 @@ export let runCryptoDriverTests = (driver: ICryptoDriver) => {
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': sha256(bytes | string) --> bytes', (t: any) => {
+    t.test(SUBTEST_NAME + ': sha256(bytes | string) --> bytes', async (t: any) => {
         let vectors : [Uint8Array | string | Buffer, Uint8Array][] = [
             // input, output
             ['', base32StringToBytes('b4oymiquy7qobjgx36tejs35zeqt24qpemsnzgtfeswmrw6csxbkq')],
@@ -45,7 +45,7 @@ export let runCryptoDriverTests = (driver: ICryptoDriver) => {
             [stringToBuffer(snowmanString), base32StringToBytes('bkfsdgyoht3fo6jni32ac3yspk4f2exm4fxy5elmu7lpbdnhum3ga')],
         ];
         for (let [input, expectedResult] of vectors) {
-            let actualResult = driver.sha256(input);
+            let actualResult = await driver.sha256(input);
             t.same(identifyBufOrBytes(actualResult), 'bytes', 'sha256 outputs bytes');
             t.same(actualResult.length, 32, 'sha256 outputs 32 bytes');
             t.same(actualResult, expectedResult, `hash of bytes or string: ${JSON.stringify(input)}`)
@@ -53,36 +53,36 @@ export let runCryptoDriverTests = (driver: ICryptoDriver) => {
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': generateKeypairBytes', (t: any) => {
-        let keypair = driver.generateKeypairBytes();
+    t.test(SUBTEST_NAME + ': generateKeypairBytes', async (t: any) => {
+        let keypair = await driver.generateKeypairBytes();
         t.same(identifyBufOrBytes(keypair.pubkey), 'bytes', 'keypair.pubkey is bytes');
         t.same(identifyBufOrBytes(keypair.secret), 'bytes', 'keypair.secret is bytes');
         t.same(keypair.pubkey.length, 32, 'pubkey is 32 bytes long');
         t.same(keypair.secret.length, 32, 'secret is 32 bytes long');
         t.notSame(keypair.secret, keypair.pubkey, 'secret is !== pubkey');
 
-        let keypair2 = driver.generateKeypairBytes();
+        let keypair2 = await driver.generateKeypairBytes();
         t.notSame(keypair.pubkey, keypair2.pubkey, 'generateKeypairBytes is non-deterministic (pubkey)');
         t.notSame(keypair.secret, keypair2.secret, 'generateKeypairBytes is non-deterministic (secret)');
 
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': sign and verify', (t: any) => {
-        let keypairBytes = driver.generateKeypairBytes();
+    t.test(SUBTEST_NAME + ': sign and verify', async (t: any) => {
+        let keypairBytes = await driver.generateKeypairBytes();
         let msg = 'hello'
-        let sigBytes = driver.sign(keypairBytes, msg);
+        let sigBytes = await driver.sign(keypairBytes, msg);
 
         t.same(identifyBufOrBytes(sigBytes), 'bytes', 'signature is bytes, not buffer');
         t.same(sigBytes.length, 64, 'sig is 64 bytes long');
 
-        t.ok(driver.verify(keypairBytes.pubkey, sigBytes, msg), 'signature is valid');
+        t.ok(await driver.verify(keypairBytes.pubkey, sigBytes, msg), 'signature is valid');
 
-        t.notOk(driver.verify(keypairBytes.pubkey, sigBytes, msg+'!'), 'signature is invalid after message is changed');
+        t.notOk(await driver.verify(keypairBytes.pubkey, sigBytes, msg+'!'), 'signature is invalid after message is changed');
 
         // change the sig and see if it's still valid
         sigBytes[0] = (sigBytes[0] + 1) % 256;
-        t.notOk(driver.verify(keypairBytes.pubkey, sigBytes, msg), 'signature is invalid after signature is changed');
+        t.notOk(await driver.verify(keypairBytes.pubkey, sigBytes, msg), 'signature is invalid after signature is changed');
 
         t.end();
     });

--- a/src/test/shared-test-code/crypto-keypair.shared.ts
+++ b/src/test/shared-test-code/crypto-keypair.shared.ts
@@ -35,11 +35,11 @@ export let runCryptoKeypairTests = (driver: ICryptoDriver) => {
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': encode/decode author keypair: from bytes to string and back', (t: any) => {
+    t.test(SUBTEST_NAME + ': encode/decode author keypair: from bytes to string and back', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
         let shortname = 'test';
-        let keypair = Crypto.generateAuthorKeypair(shortname);
+        let keypair = await Crypto.generateAuthorKeypair(shortname);
         if (isErr(keypair)) {
             t.ok(false, 'keypair 1 is an error');
             t.end();

--- a/src/test/shared-test-code/crypto.shared.ts
+++ b/src/test/shared-test-code/crypto.shared.ts
@@ -40,7 +40,7 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    t.test(SUBTEST_NAME + ': sha256 of strings', (t: any) => {
+    t.test(SUBTEST_NAME + ': sha256 of strings', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
         let vectors : [string, string][] = [
@@ -51,13 +51,13 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
         ];
 
         for (let [input, output] of vectors) {
-            t.equal(Crypto.sha256base32(input), output, `hash of ${JSON.stringify(input)}`);
+            t.equal(await Crypto.sha256base32(input), output, `hash of ${JSON.stringify(input)}`);
         }
         t.same(driver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  should be ${(driver as any).name}, was ${(GlobalCryptoDriver as any).name}`)
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': sha256 of bytes', (t: any) => {
+    t.test(SUBTEST_NAME + ': sha256 of bytes', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
         let vectors : [Uint8Array, string][] = [
@@ -70,25 +70,25 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
             [snowmanBytes, 'bkfsdgyoht3fo6jni32ac3yspk4f2exm4fxy5elmu7lpbdnhum3ga'],
         ];
         for (let [input, output] of vectors) {
-            t.equal(Crypto.sha256base32(input), output, `hash of bytes: ${JSON.stringify(input)}`)
+            t.equal(await Crypto.sha256base32(input), output, `hash of bytes: ${JSON.stringify(input)}`)
         }
         t.same(driver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  should be ${(driver as any).name}, was ${(GlobalCryptoDriver as any).name}`)
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': generateAuthorKeypair', (t: any) => {
+    t.test(SUBTEST_NAME + ': generateAuthorKeypair', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
-        t.ok(isErr(Crypto.generateAuthorKeypair('abc')), 'error when author shortname is too short');
-        t.ok(isErr(Crypto.generateAuthorKeypair('abcde')), 'error when author shortname is too long');
-        t.ok(isErr(Crypto.generateAuthorKeypair('TEST')), 'error when author shortname is uppercase');
-        t.ok(isErr(Crypto.generateAuthorKeypair('1abc')), 'error when author shortname starts with a number');
-        t.ok(isErr(Crypto.generateAuthorKeypair('abc-')), 'error when author shortname has dashes');
-        t.ok(isErr(Crypto.generateAuthorKeypair('abc.')), 'error when author shortname has a dot');
-        t.ok(isErr(Crypto.generateAuthorKeypair('abc ')), 'error when author shortname has a space');
-        t.ok(isErr(Crypto.generateAuthorKeypair('')), 'error when author shortname is empty');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('abc')), 'error when author shortname is too short');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('abcde')), 'error when author shortname is too long');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('TEST')), 'error when author shortname is uppercase');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('1abc')), 'error when author shortname starts with a number');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('abc-')), 'error when author shortname has dashes');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('abc.')), 'error when author shortname has a dot');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('abc ')), 'error when author shortname has a space');
+        t.ok(isErr(await Crypto.generateAuthorKeypair('')), 'error when author shortname is empty');
 
-        let keypair = Crypto.generateAuthorKeypair('ok99');
+        let keypair = await Crypto.generateAuthorKeypair('ok99');
         if (isErr(keypair)) {
             t.ok(false, 'should have succeeded but instead was an error: ' + keypair);
             t.end();
@@ -100,7 +100,7 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
             t.ok(keypair.secret.startsWith('b'), 'keypair.secret starts with "b"');
         }
 
-        let keypair2 = Crypto.generateAuthorKeypair('ok99');
+        let keypair2 = await Crypto.generateAuthorKeypair('ok99');
         if (isErr(keypair2)) {
             t.ok(false, 'should have succeeded but instead was an error: ' + keypair2);
         } else {
@@ -112,11 +112,11 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': authorKeypairIsValid', (t: any) => {
+    t.test(SUBTEST_NAME + ': authorKeypairIsValid', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
-        let keypair1 = Crypto.generateAuthorKeypair('onee');
-        let keypair2 = Crypto.generateAuthorKeypair('twoo');
+        let keypair1 = await Crypto.generateAuthorKeypair('onee');
+        let keypair2 = await Crypto.generateAuthorKeypair('twoo');
         if (isErr(keypair1)) { 
             t.ok(false, 'keypair1 was not generated successfully');
             t.end();
@@ -128,59 +128,59 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
             return;
         }
 
-        t.equal(Crypto.checkAuthorKeypairIsValid(keypair1), true, 'keypair1 is valid');
+        t.equal(await Crypto.checkAuthorKeypairIsValid(keypair1), true, 'keypair1 is valid');
         t.notSame(keypair1.secret, keypair2.secret, 'different keypairs have different secrets');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: '',
             secret: keypair1.secret,
         })), 'empty address makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: '',
         })), 'empty secret makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address + 'a',
             secret: keypair1.secret,
         })), 'adding char to pubkey makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: keypair1.secret + 'a'
         })), 'adding char to secret makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address.slice(0, -8) + 'aaaaaaaa',
             secret: keypair1.secret,
         })), 'altering pubkey makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: keypair1.secret.slice(0, -8) + 'aaaaaaaa',
         })), 'altering secret makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: keypair2.secret,
         })), 'mixing address and secret from 2 different keypairs is invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: keypair1.secret.slice(0, -1) + '1',  // 1 is not a valid b32 character
         })), 'invalid b32 char in address makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
             secret: keypair1.secret.slice(0, -1) + '1',  // 1 is not a valid b32 character
         })), 'invalid b32 char in secret makes keypair invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             secret: keypair1.secret,
         } as any)), 'missing address is invalid');
 
-        t.ok(isErr(Crypto.checkAuthorKeypairIsValid({
+        t.ok(isErr(await Crypto.checkAuthorKeypairIsValid({
             address: keypair1.address,
         } as any)), 'missing secret is invalid');
 
@@ -188,11 +188,11 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': encode/decode author keypair: from bytes to string and back', (t: any) => {
+    t.test(SUBTEST_NAME + ': encode/decode author keypair: from bytes to string and back', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
         let shortname = 'test';
-        let keypair = Crypto.generateAuthorKeypair(shortname);
+        let keypair = await Crypto.generateAuthorKeypair(shortname);
         if (isErr(keypair)) {
             t.ok(false, 'keypair 1 is an error');
             t.end();
@@ -234,20 +234,20 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
         t.end();
     });
 
-    t.test(SUBTEST_NAME + ': signatures', (t: any) => {
+    t.test(SUBTEST_NAME + ': signatures', async (t: any) => {
         setGlobalCryptoDriver(driver);
 
         let input = 'abc';
 
-        let keypair = Crypto.generateAuthorKeypair('test') as AuthorKeypair;
-        let keypair2 = Crypto.generateAuthorKeypair('fooo') as AuthorKeypair;
+        let keypair = await Crypto.generateAuthorKeypair('test') as AuthorKeypair;
+        let keypair2 = await Crypto.generateAuthorKeypair('fooo') as AuthorKeypair;
         if (isErr(keypair) || isErr(keypair2)) {
             t.ok(false, 'keypair generation error');
             t.end(); return;
         }
 
-        let sig = Crypto.sign(keypair, input);
-        let sig2 = Crypto.sign(keypair2, input);
+        let sig = await Crypto.sign(keypair, input);
+        let sig2 = await Crypto.sign(keypair2, input);
         if (isErr(sig)) {
             t.ok(false, 'signature error ' + sig);
             t.end(); return;
@@ -257,24 +257,24 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
             t.end(); return;
         }
 
-        t.ok(Crypto.verify(keypair.address, sig, input), 'real signature is valid');
+        t.ok(await Crypto.verify(keypair.address, sig, input), 'real signature is valid');
 
         // ways a signature should fail
-        t.notOk(Crypto.verify(keypair.address, 'bad sig', input), 'garbage signature is not valid');
-        t.notOk(Crypto.verify(keypair.address, sig2, input), 'signature from another key is not valid');
-        t.notOk(Crypto.verify(keypair.address, sig, 'different input'), 'signature is not valid with different input');
-        t.notOk(Crypto.verify('@bad.address', sig, input), 'invalid author address = invalid signature, return false');
+        t.notOk(await Crypto.verify(keypair.address, 'bad sig', input), 'garbage signature is not valid');
+        t.notOk(await Crypto.verify(keypair.address, sig2, input), 'signature from another key is not valid');
+        t.notOk(await Crypto.verify(keypair.address, sig, 'different input'), 'signature is not valid with different input');
+        t.notOk(await Crypto.verify('@bad.address', sig, input), 'invalid author address = invalid signature, return false');
 
         // determinism
-        t.equal(Crypto.sign(keypair, 'aaa'), Crypto.sign(keypair, 'aaa'), 'signatures should be deterministic');
+        t.equal(await Crypto.sign(keypair, 'aaa'), await Crypto.sign(keypair, 'aaa'), 'signatures should be deterministic');
 
         // changing input should change signature
-        t.notEqual(Crypto.sign(keypair, 'aaa'), Crypto.sign(keypair, 'xxx'), 'different inputs should make different signature');
-        t.notEqual(Crypto.sign(keypair, 'aaa'), Crypto.sign(keypair2, 'aaa'), 'different keys should make different signature');
+        t.notEqual(await Crypto.sign(keypair, 'aaa'), await Crypto.sign(keypair, 'xxx'), 'different inputs should make different signature');
+        t.notEqual(await Crypto.sign(keypair, 'aaa'), await Crypto.sign(keypair2, 'aaa'), 'different keys should make different signature');
 
         // encoding of input msg
-        let snowmanStringSig = Crypto.sign(keypair, snowmanString);
-        let snowmanBytesSig = Crypto.sign(keypair, snowmanBytes);
+        let snowmanStringSig = await Crypto.sign(keypair, snowmanString);
+        let snowmanBytesSig = await Crypto.sign(keypair, snowmanBytes);
         if (isErr(snowmanStringSig)) {
             t.ok(false, 'signature error ' + snowmanStringSig);
             t.end(); return;
@@ -283,8 +283,8 @@ export let runCryptoTests = (driver: ICryptoDriver) => {
             t.ok(false, 'signature error ' + snowmanBytesSig);
             t.end(); return;
         }
-        t.ok(Crypto.verify(keypair.address, snowmanStringSig, snowmanString), 'signature roundtrip works on snowman utf-8 string');
-        t.ok(Crypto.verify(keypair.address, snowmanBytesSig, snowmanBytes), 'signature roundtrip works on snowman Uint8Array');
+        t.ok(await Crypto.verify(keypair.address, snowmanStringSig, snowmanString), 'signature roundtrip works on snowman utf-8 string');
+        t.ok(await Crypto.verify(keypair.address, snowmanBytesSig, snowmanBytes), 'signature roundtrip works on snowman Uint8Array');
 
         t.same(driver, GlobalCryptoDriver, `GlobalCryptoDriver has not changed unexpectedly.  should be ${(driver as any).name}, was ${(GlobalCryptoDriver as any).name}`)
         t.end();

--- a/src/test/shared-test-code/peer-client-server.shared.ts
+++ b/src/test/shared-test-code/peer-client-server.shared.ts
@@ -55,7 +55,7 @@ export let runPeerClientServerTests = (subtestName: string, makeStorage: (ws: Wo
     /* istanbul ignore next */ 
     (t.test as any)?.onFinish?.(() => onFinishOneTest(TEST_NAME, SUBTEST_NAME));
 
-    let setupTest = () => {
+    let setupTest = async () => {
         let clientWorkspaces = [
             '+common.one',
             '+common.two',
@@ -88,9 +88,9 @@ export let runPeerClientServerTests = (subtestName: string, makeStorage: (ws: Wo
         }
 
         // make some identities
-        let author1 = Crypto.generateAuthorKeypair('onee');
-        let author2 = Crypto.generateAuthorKeypair('twoo');
-        let author3 = Crypto.generateAuthorKeypair('thre');
+        let author1 = await Crypto.generateAuthorKeypair('onee');
+        let author2 = await Crypto.generateAuthorKeypair('twoo');
+        let author3 = await Crypto.generateAuthorKeypair('thre');
 
         if (isErr(author1)) { throw author1; }
         if (isErr(author2)) { throw author2; }
@@ -109,7 +109,7 @@ export let runPeerClientServerTests = (subtestName: string, makeStorage: (ws: Wo
     t.test(SUBTEST_NAME + ': getServerPeerId', async (t: any) => {
         let initialCryptoDriver = GlobalCryptoDriver;
 
-        let { peerOnClient, peerOnServer } = setupTest();
+        let { peerOnClient, peerOnServer } = await setupTest();
         t.notSame(peerOnClient.peerId, peerOnServer.peerId, 'peerIds are not the same, as expected');
         let server = new PeerServer(peerOnServer);
         let client = new PeerClient(peerOnClient, server);
@@ -141,7 +141,7 @@ export let runPeerClientServerTests = (subtestName: string, makeStorage: (ws: Wo
             author1,
             author2,
             author3,
-        } = setupTest();
+        } = await setupTest();
         let server = new PeerServer(peerOnServer);
         let client = new PeerClient(peerOnClient, server);
         let workspace0 = expectedCommonWorkspaces[0];
@@ -254,7 +254,7 @@ export let runPeerClientServerTests = (subtestName: string, makeStorage: (ws: Wo
     t.test(SUBTEST_NAME + ': saltyHandshake with mini-rpc', async (t: any) => {
         let initialCryptoDriver = GlobalCryptoDriver;
 
-        let { peerOnClient, peerOnServer, expectedCommonWorkspaces } = setupTest();
+        let { peerOnClient, peerOnServer, expectedCommonWorkspaces } = await setupTest();
 
         // create Client and Server instances
         let serverLocal = new PeerServer(peerOnServer);

--- a/src/test/universal/platform.universal.ts
+++ b/src/test/universal/platform.universal.ts
@@ -3,6 +3,7 @@ import { ICryptoDriver } from '../../crypto/crypto-types';
 import { IStorageDriverAsync } from '../../storage/storage-types';
 
 import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
+import { CryptoDriverNoble} from '../../crypto/crypto-driver-noble';
 
 import { StorageDriverAsyncMemory } from '../../storage/storage-driver-async-memory';
 
@@ -10,6 +11,7 @@ import { StorageDriverAsyncMemory } from '../../storage/storage-driver-async-mem
 
 export let cryptoDrivers_universal: ICryptoDriver[] = [
     CryptoDriverTweetnacl,
+    CryptoDriverNoble,
 ];
 
 export let storageDriversAsync_universal: ClassThatImplements<IStorageDriverAsync>[] = [

--- a/src/test/universal/storage-cache.test.ts
+++ b/src/test/universal/storage-cache.test.ts
@@ -23,6 +23,7 @@ import {
     LogLevel,
     setDefaultLogLevel,
 } from '../../util/log';
+import { sleep } from "../../util/misc";
 
 //setDefaultLogLevel(LogLevel.Debug);
 
@@ -30,9 +31,9 @@ import {
 
 const WORKSPACE_ADDR = "+test.a123";
 
-t.test("works", (t: any) => {
-  const keypair = Crypto.generateAuthorKeypair("test") as AuthorKeypair;
-  const keypairB = Crypto.generateAuthorKeypair("suzy") as AuthorKeypair;
+t.test("works", async (t: any) => {
+  const keypair = await Crypto.generateAuthorKeypair("test") as AuthorKeypair;
+  const keypairB = await Crypto.generateAuthorKeypair("suzy") as AuthorKeypair;
 
   const storage = new StorageAsync(
     WORKSPACE_ADDR,
@@ -58,34 +59,38 @@ t.test("works", (t: any) => {
   t.same(values.latestDocs, []);
   t.equals(values.orangesDoc, undefined);
 
-  cache.set(keypair, {
+  cache._storage.set(keypair, {
     content: "Hello!",
     path: "/test/hello.txt",
     format: "es.4",
   });
 
-  cache.set(keypair, {
+  cache._storage.set(keypair, {
     content: "Apples!",
     path: "/test/apples.txt",
     format: "es.4",
   });
 
-  cache.set(keypair, {
+  cache._storage.set(keypair, {
     content: "Oranges!",
     path: "/test/oranges.txt",
     format: "es.4",
   });
+  
+  await sleep(100);
 
   t.equals(values.allDocs.length, 3);
   t.equals(values.latestDocs.length, 3);
   t.equals(values.orangesDoc?.path, "/test/oranges.txt");
   t.equals(values.orangesDoc?.author, keypair.address);
 
-  cache.set(keypairB, {
+  cache._storage.set(keypairB, {
     content: "Suzy's Oranges!",
     path: "/test/oranges.txt",
     format: "es.4",
   });
+  
+  await sleep(100);
 
   t.equals(values.allDocs.length, 4);
   t.equals(values.latestDocs.length, 3);

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,11 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@noble/ed25519@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.3.0.tgz#a55b6bdd18991d6051f819e9c71d9341706a751e"
+  integrity sha512-k6ddjHcmfHF5LoZRv2j7WktgY8C8lzAqiu5ukWfGIlPUlpLn1tn1pfILXaXHY1DCG0s3qvGM1SluLtVpckWwMA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
## What's the problem you solved?

Currently we use tweetnacl as the default crypto driver, as it was the only universal solution we had. It's quite slow.

There is another package with much better performance, [noble/ed25519](https://github.com/paulmillr/noble-ed25519) but it had an asynchronous interface.

## What solution are you recommending?

- Changed `ICrypto's` methods to be asynchronous, which in turn made a few things in `FormValidator` asynchronous.
- Updated tests to reflect this new API
- Added a new `CryptoDriverNoble` crypto driver
- Made this new driver the default driver

Should we remove the TweetNacl driver? 