### PR TITLE
Add StorageDriverSqliteNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@earthstar-project/mini-rpc": "^2.1.0",
+    "@types/better-sqlite3": "^7.4.2",
     "@types/browser-or-node": "^1.3.0",
     "@types/node": "^14.14.43",
     "@types/tap": "^14.10.2",
@@ -100,6 +101,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^1.3.0",
+    "better-sqlite3": "^7.4.6",
     "chalk": "^4.1.1",
     "chloride": "^2.4.1",
     "concurrency-friends": "^5.0.1",

--- a/src/entries/node.ts
+++ b/src/entries/node.ts
@@ -1,1 +1,2 @@
 export * from '../crypto/crypto-driver-node';
+export * from '../storage/storage-driver-sqlite-node';

--- a/src/storage/storage-driver-sqlite-node.ts
+++ b/src/storage/storage-driver-sqlite-node.ts
@@ -1,0 +1,634 @@
+import { Doc, WorkspaceAddress } from "../util/doc-types";
+import {
+  EarthstarError,
+  StorageIsClosedError,
+  ValidationError,
+} from "../util/errors";
+import { IStorageDriverAsync } from "./storage-types";
+import { default as sqlite, Database as SqliteDatabase } from "better-sqlite3";
+import * as fs from "fs";
+
+//--------------------------------------------------
+
+import { Logger } from "../util/log";
+import { bytesToString, stringToBytes } from "../util/bytes";
+import { Query } from "../query/query-types";
+import { cleanUpQuery } from "../query/query";
+import { sortedInPlace } from "..";
+let logger = new Logger("storage driver sqlite node", "yellow");
+
+interface StorageSqliteOptsCreate {
+  mode: "create";
+  workspace: WorkspaceAddress;
+  filename: string; // must not exist
+}
+interface StorageSqliteOptsOpen {
+  mode: "open";
+  workspace: WorkspaceAddress | null;
+  filename: string; // must exist
+}
+interface StorageSqliteOptsCreateOrOpen {
+  mode: "create-or-open";
+  workspace: WorkspaceAddress;
+  filename: string; // may or may not exist
+}
+export type StorageSqliteNodeOpts =
+  | StorageSqliteOptsCreate
+  | StorageSqliteOptsOpen
+  | StorageSqliteOptsCreateOrOpen;
+
+export class StorageDriverSqliteNode implements IStorageDriverAsync {
+  workspace: WorkspaceAddress;
+  _filename: string;
+  _isClosed: boolean = false;
+  _db: SqliteDatabase = null as any as SqliteDatabase;
+  _maxLocalIndex: number;
+
+  //--------------------------------------------------
+  // LIFECYCLE
+
+  async close(erase: boolean): Promise<void> {
+    logger.debug("close");
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    if (this._db) {
+      this._db.close();
+    }
+    // delete the sqlite file
+    if (erase === true && this._filename !== ":memory:") {
+      logger.log(`...close: and erase`);
+      if (fs.existsSync(this._filename)) {
+        fs.unlinkSync(this._filename);
+      }
+    }
+    this._isClosed = true;
+    logger.debug("...close is done.");
+  }
+
+  isClosed(): boolean {
+    return this._isClosed;
+  }
+
+  constructor(opts: StorageSqliteNodeOpts) {
+    this._filename = opts.filename;
+    this.workspace = "NOT_INITIALIZED";
+
+    // check if file exists
+    if (opts.mode === "create") {
+      if (opts.filename !== ":memory:" && fs.existsSync(opts.filename)) {
+        this.close(false);
+        throw new EarthstarError(
+          `Tried to create an sqlite file but it already exists: ${opts.filename}`
+        );
+      }
+    } else if (opts.mode === "open") {
+      // this should also fail if you try to open :memory:
+      if (!fs.existsSync(opts.filename)) {
+        this.close(false);
+        throw new EarthstarError(
+          `Tried to open an sqlite file but it doesn't exist: ${opts.filename}`
+        );
+      }
+    } else if (opts.mode === "create-or-open") {
+      // file can exist or not.
+    } else {
+      // unknown mode
+      this.close(false);
+      throw new EarthstarError(
+        `sqlite unrecognized opts.mode: ${(opts as any).mode}`
+      );
+    }
+
+    this._db = sqlite(this._filename);
+    this._ensureTables();
+
+    const maxLocalIndexFromDb = this._db
+      .prepare(
+        `
+          SELECT MAX(localIndex) from docs;
+      `
+      )
+      .get();
+
+    this._maxLocalIndex = maxLocalIndexFromDb["MAX(localIndex)"] || -1;
+
+    // check workspace
+    if (opts.mode === "create") {
+      // workspace is provided; set it into the file which we know didn't exist until just now
+      this.workspace = opts.workspace;
+      this.setConfig("workspace", this.workspace);
+    } else if (opts.mode === "open") {
+      // load existing workspace from file, which we know already existed...
+      let existingWorkspace = this._getConfigSync("workspace");
+      if (existingWorkspace === undefined) {
+        this.close(false);
+        throw new EarthstarError(
+          `can't open sqlite file with opts.mode="open" because the file doesn't have a workspace saved in its config table. ${opts.filename}`
+        );
+      }
+      // if it was also provided in opts, assert that it matches the file
+      if (
+        opts.workspace !== null &&
+        opts.workspace !== this._getConfigSync("workspace")
+      ) {
+        this.close(false);
+        throw new EarthstarError(
+          `sqlite with opts.mode="open" wanted workspace ${opts.workspace} but found ${existingWorkspace} in the file ${opts.filename}`
+        );
+      }
+      this.workspace = existingWorkspace;
+    } else if (opts.mode === "create-or-open") {
+      // workspace must be provided
+      if (opts.workspace === null) {
+        this.close(false);
+        throw new EarthstarError(
+          'sqlite with opts.mode="create-or-open" must have a workspace provided, not null'
+        );
+      }
+      this.workspace = opts.workspace;
+
+      // existing workspace can be undefined (file may not have existed yet)
+      let existingWorkspace = this._getConfigSync("workspace");
+
+      // if there is an existing workspace, it has to match the one given in opts
+      if (
+        existingWorkspace !== undefined &&
+        opts.workspace !== existingWorkspace
+      ) {
+        this.close(false);
+        throw new EarthstarError(
+          `sqlite file had existing workspace ${existingWorkspace} but opts wanted it to be ${opts.workspace} in file ${opts.filename}`
+        );
+      }
+
+      // set workspace if it's not set yet
+      if (existingWorkspace === undefined) {
+        this.setConfig("workspace", opts.workspace);
+      }
+
+      this.workspace = opts.workspace;
+    }
+
+    // check and set schemaVersion
+    let schemaVersion = this._getConfigSync("schemaVersion");
+    logger.log(`constructor    schemaVersion: ${schemaVersion}`);
+    /* istanbul ignore else */
+    if (schemaVersion === undefined) {
+      schemaVersion = "1";
+      this.setConfig("schemaVersion", schemaVersion);
+    } else if (schemaVersion !== "1") {
+      this.close(false);
+      throw new ValidationError(
+        `sqlite file ${this._filename} has unknown schema version ${schemaVersion}`
+      );
+    }
+
+    // get maxlocalindex
+  }
+
+  //--------------------------------------------------
+  // CONFIG
+
+  async setConfig(key: string, content: string): Promise<void> {
+    logger.debug(
+      `setConfig(${JSON.stringify(key)} = ${JSON.stringify(content)})`
+    );
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    this._db
+      .prepare(
+        `
+          INSERT OR REPLACE INTO config (key, content) VALUES (:key, :content);
+      `
+      )
+      .run({ key: key, content: content });
+  }
+
+  _getConfigSync(key: string): string | undefined {
+    const row = this._db
+      .prepare(
+        `
+          SELECT content FROM config WHERE key = :key;
+      `
+      )
+      .get({ key: key });
+    const result = row === undefined ? undefined : row.content;
+    logger.debug(
+      `getConfig(${JSON.stringify(key)}) = ${JSON.stringify(result)}`
+    );
+    return result;
+  }
+
+  _listConfigKeysSync(): string[] {
+    const rows = this._db
+      .prepare(
+        `
+          SELECT key FROM config;
+      `
+      )
+      .all();
+    return sortedInPlace(rows.map((row) => row.key));
+  }
+
+  async getConfig(key: string): Promise<string | undefined> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    return this._getConfigSync(key);
+  }
+
+  async listConfigKeys(): Promise<string[]> {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    return this._listConfigKeysSync();
+  }
+
+  async deleteConfig(key: string): Promise<boolean> {
+    logger.debug(`deleteConfig(${JSON.stringify(key)})`);
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+    const result = this._db
+      .prepare(
+        `
+          DELETE FROM config WHERE key = :key;
+      `
+      )
+      .run({ key: key });
+
+    return result.changes > 0;
+  }
+
+  //--------------------------------------------------
+  // GET
+
+  getMaxLocalIndex(): number {
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    return this._maxLocalIndex;
+  }
+
+  async queryDocs(queryToClean: Query): Promise<Doc[]> {
+    // Query the documents
+
+    logger.debug("queryDocs", queryToClean);
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    // clean up the query and exit early if possible.
+    let { query, willMatch } = cleanUpQuery(queryToClean);
+    logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
+    if (willMatch === "nothing") {
+      return [];
+    }
+    let now = Date.now() * 1000;
+
+    let { sql, params } = this._makeDocQuerySql(query, now, "documents");
+    logger.debug("  sql:", sql);
+    logger.debug("  params:", params);
+
+    let docs = this._db.prepare(sql).all(params);
+
+    if (query.historyMode === "latest") {
+      // remove extra field we added to find the winner within each path
+      docs.forEach((d) => {
+        delete (d as any).toSortWithinPath;
+      });
+    }
+
+    // TODO: limitBytes, when this is added back to Query
+
+    // Transform the content from the DB (saved as BLOB) back to string
+    const docsWithStringContent = docs.map((doc) => ({
+      ...doc,
+      content: bytesToString(doc.content),
+      _localIndex: doc.localIndex,
+    }));
+
+    docsWithStringContent.forEach((doc) => delete doc["localIndex"]);
+    docsWithStringContent.forEach((doc) => Object.freeze(doc));
+    logger.debug(`  result: ${docs.length} docs`);
+    return docsWithStringContent;
+  }
+
+  //--------------------------------------------------
+  // SET
+
+  async upsert(doc: Doc): Promise<Doc> {
+    // Insert new doc, replacing old doc if there is one
+    logger.debug(`upsertDocument(doc.path: ${JSON.stringify(doc.path)})`);
+
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    Object.freeze(doc);
+    const docWithLocalIndex = {
+      ...doc,
+      _localIndex: this._maxLocalIndex + 1,
+    };
+
+    this._maxLocalIndex += 1;
+
+    const contentAsBytes = stringToBytes(doc.content);
+
+    const docWithBuffer = {
+      ...docWithLocalIndex,
+      content: contentAsBytes,
+    };
+
+    this._db
+      .prepare(
+        `
+          INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
+          VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);
+      `
+      )
+      .run(docWithBuffer);
+
+    return docWithLocalIndex;
+  }
+
+  //--------------------------------------------------
+  // SQL STUFF
+
+  _ensureTables() {
+    // for each path and author we can have at most one document
+
+    // TODO: how to tell if we're loading an old sqlite file with old schema?
+
+    if (this._isClosed) {
+      throw new StorageIsClosedError();
+    }
+
+    // make sure sqlite is using utf-8
+    let encoding = this._db.pragma("encoding", { simple: true });
+    if (encoding !== "UTF-8") {
+      throw new Error(
+        `sqlite encoding is stubbornly set to ${encoding} instead of UTF-8`
+      );
+    }
+
+    this._db
+      .prepare(
+        `
+          CREATE TABLE IF NOT EXISTS docs (
+              format TEXT NOT NULL,
+              workspace TEXT NOT NULL,
+              path TEXT NOT NULL,
+              contentHash TEXT NOT NULL,
+              content BLOB NOT NULL,
+              author TEXT NOT NULL,
+              timestamp NUMBER NOT NULL,
+              deleteAfter NUMBER,  -- can be null
+              signature TEXT NOT NULL,
+              localIndex NUMBER NOT NULL UNIQUE,
+              PRIMARY KEY(path, author)
+          );
+      `
+      )
+      .run();
+
+    this._db
+      .prepare(`CREATE INDEX IF NOT EXISTS idx1 ON docs(localIndex);`)
+      .run();
+
+    // the config table is used to store these variables:
+    //     workspace - the workspace this store was created for
+    //     schemaVersion
+    this._db
+      .prepare(
+        `
+          CREATE TABLE IF NOT EXISTS config (
+              key TEXT NOT NULL PRIMARY KEY,
+              content TEXT NOT NULL
+          );
+      `
+      )
+      .run();
+  }
+
+  _makeDocQuerySql(
+    query: Query,
+    now: number,
+    mode: "documents" | "delete"
+  ): { sql: string; params: Record<string, any> } {
+    /**
+     * Internal function to make SQL to query for documents or paths,
+     * or delete documents matching a query.
+     *
+     * Assumes query has already been through cleanUpQuery(q).
+     *
+     * If query.history === 'all', we can do an easy query:
+     *
+     * ```
+     *     SELECT * from DOCS
+     *     WHERE path = "/abc"
+     *         AND timestamp > 123
+     *     ORDER BY path ASC, author ASC
+     *     LIMIT 123
+     * ```
+     *
+     * If query.history === 'latest', we have to do something more complicated.
+     * We don't want to filter out some docs, and THEN get the latest REMAINING
+     * docs in each path.
+     * We want to first get the latest doc per path, THEN filter those.
+     *
+     * ```
+     *     SELECT *, MAX(timestamp) from DOCS
+     *     -- first level of filtering happens before we choose the latest doc.
+     *     -- here we can only do things that are the same for all docs in a path.
+     *     WHERE path = "/abc"
+     *     -- now group by path and keep the newest one
+     *     GROUP BY path
+     *     -- finally, second level of filtering happens AFTER we choose the latest doc.
+     *     -- these are things that can differ for docs within a path
+     *     HAVING timestamp > 123
+     *     ORDER BY path ASC, author ASC
+     *     LIMIT 123
+     * ```
+     */
+
+    let select = "";
+    let from = "FROM docs";
+    let wheres: string[] = [];
+    let groupBy = "";
+    let havings: string[] = [];
+    let orderBy = "";
+    let limit = "";
+
+    switch (query.orderBy) {
+      case "path ASC":
+        //   "path ASC" is actually "path ASC then break ties with timestamp DESC"
+        orderBy = "ORDER BY path ASC, timestamp DESC";
+        break;
+      case "path DESC":
+        //   "path DESC" is the reverse of that
+        orderBy = "ORDER BY path DESC, timestamp ASC";
+        break;
+      case "localIndex ASC":
+        orderBy = "ORDER BY localIndex ASC";
+        break;
+      case "localIndex DESC":
+        orderBy = "ORDER BY localIndex DESC";
+        break;
+    }
+
+    let params: Record<string, any> = {};
+    let sql = "";
+
+    if (mode === "documents") {
+      if (query.historyMode === "all") {
+        select = "SELECT *";
+      } else if (query.historyMode === "latest") {
+        // We're going to GROUP BY path and want to get the doc with the highest timestamp.
+        // To break timestamp ties, we'll use the signature.
+        // Because we need to look at multiple columns to choose the winner of the group
+        // we can't just do MAX(timestamp), we have to do this silly thing instead:
+        // TODO: test sorting by signature when timestamp is tied
+        select =
+          "SELECT *, MIN(CAST(9999999999999999 - timestamp AS TEXT) || signature) AS toSortWithinPath";
+        //select = 'SELECT *, MAX(timestamp) AS toSortWithinPath';
+        groupBy = "GROUP BY path";
+      } else {
+        throw new ValidationError(
+          `unexpected query.historyMode = ${query.historyMode}`
+        );
+      }
+    } else if (mode === "delete") {
+      if (query.historyMode === "all") {
+        select = "DELETE";
+      } else {
+        throw new ValidationError(
+          `query.history must be "all" when doing forgetDocuments`
+        );
+      }
+    } else {
+      // if (mode === 'paths') {
+
+      throw new Error("unknown mode to _makeDocQuerySql: " + mode);
+      //select = 'SELECT DISTINCT path';
+    }
+
+    // parts of the query that are the same for all docs in a path can go in WHERE.
+
+    if (query.filter?.path !== undefined) {
+      wheres.push("path = :path");
+      params.path = query.filter.path;
+    }
+    // If we have pathStartsWith AND pathEndsWith we would want to optimize them
+    // into a single filter, path LIKE (:startsWith || '%' || :endsWith).
+    // BUT we can't do that because we are allowing the prefix and suffix
+    // to potentially overlap,
+    // leaving no room in the middle for the wildcard to match anything.
+    // So this has to be left as two separate filter clauses.
+    if (query.filter?.pathStartsWith !== undefined) {
+      // Escape existing % and _ in the prefix so they don't count as wildcards for LIKE.
+      // TODO: test this
+      wheres.push("path LIKE (:startsWith || '%') ESCAPE '\\'");
+      params.startsWith = query.filter.pathStartsWith
+        .split("_")
+        .join("\\_")
+        .split("%")
+        .join("\\%");
+    }
+    if (query.filter?.pathEndsWith !== undefined) {
+      // Escape existing % and _ in the suffix so they don't count as wildcards for LIKE.
+      // TODO: test this
+      wheres.push("path LIKE ('%' || :endsWith) ESCAPE '\\'");
+      params.endsWith = query.filter.pathEndsWith
+        .split("_")
+        .join("\\_")
+        .split("%")
+        .join("\\%");
+    }
+
+    // parts of the query that differ across docs in the same path
+    // may have to go in HAVING if we're doing a GROUP BY.
+    if (query.filter?.timestamp !== undefined) {
+      havings.push("timestamp = :timestamp");
+      params.timestamp = query.filter.timestamp;
+    }
+    if (query.filter?.timestampGt !== undefined) {
+      havings.push("timestamp > :timestampGt");
+      params.timestampGt = query.filter.timestampGt;
+    }
+    if (query.filter?.timestampLt !== undefined) {
+      havings.push("timestamp < :timestampLt");
+      params.timestampLt = query.filter.timestampLt;
+    }
+    if (query.filter?.author !== undefined) {
+      havings.push("author = :author");
+      params.author = query.filter.author;
+    }
+    // Sqlite length() counts unicode characters for TEXT and bytes for BLOB.
+    if (query.filter?.contentLength !== undefined) {
+      havings.push("length(content) = :contentLength");
+      params.contentLength = query.filter.contentLength;
+    }
+    if (query.filter?.contentLengthGt !== undefined) {
+      havings.push("length(content) > :contentLengthGt");
+      params.contentLengthGt = query.filter.contentLengthGt;
+    }
+    if (query.filter?.contentLengthLt !== undefined) {
+      havings.push("length(content) < :contentLengthLt");
+      params.contentLengthLt = query.filter.contentLengthLt;
+    }
+
+    if (query.startAfter !== undefined) {
+      if (query.orderBy?.startsWith("path ")) {
+        havings.push("path > :continuePath");
+        params.continuePath = query.startAfter.path;
+      } else if (query.orderBy?.startsWith("localIndex ")) {
+        havings.push("localIndex > :continueLocalIndex");
+        params.continueLocalIndex = query.startAfter.localIndex;
+      }
+    }
+
+    if (query.limit !== undefined && mode !== "delete") {
+      limit = "LIMIT :limit";
+      params.limit = query.limit;
+    }
+
+    // limitBytes is skipped here since it can't be expressed in SQL.
+    // it's applied after the query is run, and only for docs (not paths).
+
+    // filter out expired docs.
+    // to pretend they don't exist at all, we use WHERE instead of HAVING.
+    // otherwise they might end up as a latest doc of a group,
+    // and then disqualify that group.
+    wheres.push("(deleteAfter IS NULL OR :now <= deleteAfter)");
+    params.now = now;
+
+    // assemble the final sql
+
+    // in 'all' mode, we don't need to use HAVING, we can do all the filters as WHERE.
+    if (query.historyMode === "all") {
+      wheres = wheres.concat(havings);
+      havings = [];
+    }
+
+    let allWheres =
+      wheres.length === 0 ? "" : "WHERE " + wheres.join("\n  AND ");
+    let allHavings =
+      havings.length === 0 ? "" : "HAVING " + havings.join("\n  AND ");
+
+    sql = `
+          ${select}
+          ${from}
+          ${allWheres}
+          ${groupBy}
+          ${allHavings}
+          ${orderBy}
+          ${limit};
+      `;
+
+    return { sql, params };
+  }
+}

--- a/src/test/improved/storage-config.shared.ts
+++ b/src/test/improved/storage-config.shared.ts
@@ -58,7 +58,7 @@ let _runStorageConfigTests = (scenario: TestScenario, mode: 'storage' | 'storage
 
         // empty...
         t.same(await storage.getConfig('a'), undefined, `getConfig('nonexistent') --> undefined`);
-        t.same(await storage.listConfigKeys(), [], `listConfigKeys() is [] when empty`);
+        t.same(await storage.listConfigKeys(), scenario.builtinConfigKeys, `listConfigKeys() only contains built-in config keys`);
         t.same(await storage.deleteConfig('a'), false, `deleteConfig('nonexistent') --> false`);
 
         // set some items...
@@ -67,7 +67,7 @@ let _runStorageConfigTests = (scenario: TestScenario, mode: 'storage' | 'storage
 
         // verify items are there...
         t.same(await storage.getConfig('a'), 'aa', `getConfig works`);
-        t.same(await storage.listConfigKeys(), ['a', 'b'], `listConfigKeys() is ['a', 'b'] (sorted)`);
+        t.same(await storage.listConfigKeys(), ['a', 'b', ...scenario.builtinConfigKeys], `listConfigKeys() is ${(['a', 'b', ...scenario.builtinConfigKeys])} (sorted)`);
 
         await storage.setConfig('a', 'aaa');
         t.same(await storage.getConfig('a'), 'aaa', `getConfig overwrites old value`);
@@ -76,7 +76,7 @@ let _runStorageConfigTests = (scenario: TestScenario, mode: 'storage' | 'storage
         t.same(await storage.deleteConfig('a'), true, 'delete returns true on success');
         t.same(await storage.deleteConfig('a'), false, 'delete returns false if nothing is there');
         t.same(await storage.getConfig('a'), undefined, `getConfig returns undefined after deleting the key`);
-        t.same(await storage.listConfigKeys(), ['b'], `listConfigKeys() is ['b'] after deleting 'a'`);
+        t.same(await storage.listConfigKeys(), ['b', ...scenario.builtinConfigKeys], `listConfigKeys() is ${(['b', ...scenario.builtinConfigKeys])} after deleting 'a'`);
 
         // close without erasing
         await storage.close(false);

--- a/src/test/improved/storage-driver-async.shared.ts
+++ b/src/test/improved/storage-driver-async.shared.ts
@@ -58,7 +58,7 @@ export let runStorageDriverTests = (scenario: TestScenario) => {
 
         // empty...
         t.same(await driver.getConfig('foo'), undefined, `getConfig('nonexistent') --> undefined`);
-        t.same(await driver.listConfigKeys(), [], `listConfigKeys() is []`);
+        t.same(await driver.listConfigKeys(), scenario.builtinConfigKeys, `listConfigKeys() only contains builtin config keys: ${scenario.builtinConfigKeys}`);
         t.same(await driver.deleteConfig('foo'), false, `deleteConfig('nonexistent') --> false`);
 
         // set some items...
@@ -67,7 +67,7 @@ export let runStorageDriverTests = (scenario: TestScenario) => {
 
         // after adding some items...
         t.same(await driver.getConfig('a'), 'aa', `getConfig works`);
-        t.same(await driver.listConfigKeys(), ['a', 'b'], `listConfigKeys() is ['a', 'b'] (sorted)`);
+        t.same(await driver.listConfigKeys(), ['a', 'b', ...scenario.builtinConfigKeys], `listConfigKeys() is ${(['a', 'b', ...scenario.builtinConfigKeys])} (sorted)`);
 
         t.same(await driver.deleteConfig('a'), true, 'delete returns true on success');
         t.same(await driver.deleteConfig('a'), false, 'delete returns false if nothing is there');

--- a/src/test/improved/test-scenario-types.ts
+++ b/src/test/improved/test-scenario-types.ts
@@ -22,4 +22,5 @@ export interface TestScenario {
     // in here you will instantiate a StorageDriver and then
     // use it to instantiate a Storage:
     makeDriver: (ws: WorkspaceAddress) => IStorageDriverAsync;
+    builtinConfigKeys: string[]
 }

--- a/src/test/improved/test-scenarios.browser.ts
+++ b/src/test/improved/test-scenarios.browser.ts
@@ -3,7 +3,7 @@ import { WorkspaceAddress } from '../../util/doc-types';
 import { IStorageDriverAsync } from '../../storage/storage-types';
 
 // specific drivers
-import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
+import { CryptoDriverNoble } from '../../crypto/crypto-driver-noble';
 import { CryptoDriverChloride } from '../../crypto/crypto-driver-chloride';
 import { StorageDriverAsyncMemory } from '../../storage/storage-driver-async-memory';
 import { StorageDriverLocalStorage } from '../../storage/storage-driver-local-storage';
@@ -16,12 +16,13 @@ import { TestScenario } from './test-scenario-types';
 
 export let testScenarios: TestScenario[] = [
     {
-        name: 'StorageDriverAsyncMemory + CryptoDriverTweetnacl',
-        cryptoDriver: CryptoDriverTweetnacl,
+        name: 'StorageDriverAsyncMemory + CryptoDriverNoble',
+        cryptoDriver: CryptoDriverNoble,
         persistent: false,
         platforms: { browser: true, node: true, deno: true },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverAsyncMemory(ws),
+        builtinConfigKeys: []
     },
     {
         name: 'StorageDriverAsyncMemory + CryptoDriverChloride',
@@ -30,22 +31,25 @@ export let testScenarios: TestScenario[] = [
         platforms: { browser: true, node: true, deno: true },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverAsyncMemory(ws),
+        builtinConfigKeys: []
     },
     {
-        name: 'StorageDriverLocalStorage + CryptoDriverTweetnacl',
-        cryptoDriver: CryptoDriverTweetnacl,
+        name: 'StorageDriverLocalStorage + CryptoDriverNoble',
+        cryptoDriver: CryptoDriverNoble,
         persistent: true,
         platforms: { browser: true, node: false, deno: false },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverLocalStorage(ws),
+        builtinConfigKeys: []
     },
     {
-        name: 'StorageDriverIndexedDB + CryptoDriverTweetnacl',
-        cryptoDriver: CryptoDriverTweetnacl,
+        name: 'StorageDriverIndexedDB + CryptoDriverNoble',
+        cryptoDriver: CryptoDriverNoble,
         persistent: true,
         platforms: { browser: true, node: false, deno: false },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverIndexedDB(ws),
+        builtinConfigKeys: []
     }
 ]
 

--- a/src/test/improved/test-scenarios.node.ts
+++ b/src/test/improved/test-scenarios.node.ts
@@ -3,9 +3,10 @@ import { WorkspaceAddress } from '../../util/doc-types';
 import { IStorageDriverAsync } from '../../storage/storage-types';
 
 // specific drivers
-import { CryptoDriverTweetnacl } from '../../crypto/crypto-driver-tweetnacl';
+import { CryptoDriverNoble } from '../../crypto/crypto-driver-noble';
 import { CryptoDriverNode } from '../../crypto/crypto-driver-node';
 import { StorageDriverAsyncMemory } from '../../storage/storage-driver-async-memory';
+import { StorageDriverSqliteNode } from '../../storage/storage-driver-sqlite-node';
 
 // test types
 import { TestScenario } from './test-scenario-types';
@@ -14,12 +15,13 @@ import { TestScenario } from './test-scenario-types';
 
 export let testScenarios: TestScenario[] = [
     {
-        name: 'StorageDriverAsyncMemory + CryptoDriverTweetnacl',
-        cryptoDriver: CryptoDriverTweetnacl,
+        name: 'StorageDriverAsyncMemory + CryptoDriverNoble',
+        cryptoDriver: CryptoDriverNoble,
         persistent: false,
         platforms: { browser: true, node: true, deno: true },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
-            new StorageDriverAsyncMemory(ws),
+            new StorageDriverAsyncMemory(ws)
+            , builtinConfigKeys: []
     },
     {
         name: 'StorageDriverAsyncMemory + CryptoDriverNode',
@@ -28,7 +30,35 @@ export let testScenarios: TestScenario[] = [
         platforms: { browser: true, node: true, deno: true },
         makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
             new StorageDriverAsyncMemory(ws),
-    }
+            builtinConfigKeys: []
+    },
+    {
+        name: 'StorageDriverSqliteNode + CryptoDriverNoble',
+        cryptoDriver: CryptoDriverNoble,
+        persistent: false,
+        platforms: { browser: true, node: true, deno: true },
+        makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
+            new StorageDriverSqliteNode({
+                filename: ':memory:',
+                workspace: ws,
+                mode: 'create'
+            }),
+            builtinConfigKeys: ['schemaVersion', 'workspace']
+    },
+    {
+        name: 'StorageDriverSqliteNode + CryptoDriverNode',
+        cryptoDriver: CryptoDriverNode,
+        persistent: false,
+        platforms: { browser: true, node: true, deno: true },
+        makeDriver: (ws: WorkspaceAddress): IStorageDriverAsync =>
+            new StorageDriverSqliteNode({
+                filename: ':memory:',
+                workspace: ws,
+                mode: 'create'
+            }),
+            builtinConfigKeys: ['schemaVersion', 'workspace']
+    },
+    
 ]
 
 //================================================================================

--- a/src/test/node/peer-client-server.node.test.ts
+++ b/src/test/node/peer-client-server.node.test.ts
@@ -10,21 +10,21 @@ import { storageDriversAsync_nodeAndUniversal } from './platform.node';
 import { runPeerClientServerTests } from '../shared-test-code/peer-client-server.shared';
 import { runPeerTests } from '../shared-test-code/peer.shared';
 import { setGlobalCryptoDriver } from '../../crypto/global-crypto-driver';
+import { testScenarios } from '../improved/test-scenarios.node'
 
 //================================================================================
 
-for (let storageDriver of storageDriversAsync_nodeAndUniversal) {
+for (let scenario of testScenarios) {
     // just hardcode this crypto driver since it works on all platforms
     let cryptoDriver = CryptoDriverTweetnacl;
     setGlobalCryptoDriver(cryptoDriver);
 
-    let storageDriverName = (storageDriver as any).name;
+    let storageDriverName = scenario.name;
     let cryptoDriverName = (cryptoDriver as any).name;
     let description = `${storageDriverName} + ${cryptoDriverName}`;
 
     let makeStorage = (ws: WorkspaceAddress): IStorageAsync => {
-        let stDriver = new storageDriver(ws);
-        let storage = new StorageAsync(ws, FormatValidatorEs4, stDriver);
+        let storage = new StorageAsync(ws, FormatValidatorEs4, scenario.makeDriver(ws));
         return storage;
     }
 

--- a/src/test/node/platform.node.ts
+++ b/src/test/node/platform.node.ts
@@ -4,6 +4,8 @@ import { IStorageDriverAsync } from '../../storage/storage-types';
 
 import { CryptoDriverNode } from '../../crypto/crypto-driver-node';
 
+import { StorageDriverSqliteNode } from '../../storage/storage-driver-sqlite-node'
+
 
 import {
     cryptoDrivers_universal,
@@ -20,6 +22,7 @@ if (process && process.version >= 'v12') {
 }
 
 export let storageDriversAsync_nodeOnly: ClassThatImplements<IStorageDriverAsync>[] = [
+    StorageDriverSqliteNode
 ];
 
 //================================================================================

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,6 +318,13 @@
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-2.0.10.tgz#664e84808accd1987548d888b9d21b3e9c996a6c"
   integrity sha512-C4wahC3gz3vQtvPazrJ5ONwmK1zSDllQboiWvpMM/iOswCYfBREFnjFbq/iWKIVOCl8+m5Pk6eva6/ZSsDuIGA==
 
+"@types/better-sqlite3@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.4.2.tgz#d847464797bba607d499578c4ae708e8389e0b5b"
+  integrity sha512-HUXWMOmRgOrXJ0SKt6kxqUaZtGkr0HCuaEt/76LojT6bkTu0lb0uhr3K1su9T09mskDKyQwNMvT7WithFN10PQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/browser-or-node@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/browser-or-node/-/browser-or-node-1.3.0.tgz#896ec59bcb8109fc858d8e68d3c056c176a19622"
@@ -484,10 +491,23 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
+are-we-there-yet@~1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
 
 arg@^4.1.0, arg@^4.1.3:
   version "4.1.3"
@@ -593,7 +613,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -605,6 +625,15 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-sqlite3@^7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.4.6.tgz#c5dc35c71bb9c9ef5d9e16019686371ff6a5f25e"
+  integrity sha512-LB/UxnMhcJY12bRCDXl2jTk0lsbXHCHOLn3cPjGhy3GCcVPGq45sCGJPUdfBZnfXGN14tYTJyq0ztUI3lGng8A==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.0.0"
+    tar "^6.1.11"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -614,6 +643,22 @@ bind-obj-methods@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/bind-obj-methods/-/bind-obj-methods-2.0.2.tgz#ea603b0f2455dce76d177c69747751b40c815897"
   integrity sha512-bUkRdEOppT1Xg/jG0+bp0JSjUD9U0r7skxb/42WeBUjfBpW6COQTIgQmKX5J2Z3aMXcORKgN2N+d7IQwTK3pag==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
@@ -849,6 +894,14 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 buffer@~5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
@@ -1013,6 +1066,16 @@ chokidar@^3.3.0, chokidar@^3.3.1:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1189,6 +1252,11 @@ console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
+
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 constants-browserify@~1.0.0:
   version "1.0.0"
@@ -1382,6 +1450,13 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-equal@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.5.tgz#55cd2fe326d83f9cbf7261ef0e060b3f724c5cb9"
@@ -1402,6 +1477,11 @@ deep-equal@^2.0.5:
     which-boxed-primitive "^1.0.1"
     which-collection "^1.0.1"
     which-typed-array "^1.1.2"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -1432,6 +1512,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
 depchart@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/depchart/-/depchart-1.2.0.tgz#addcc79ed8edc07893bf6371097b2cfc4ec12faf"
@@ -1460,6 +1545,11 @@ des.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.1.0"
@@ -1632,7 +1722,7 @@ encodeurl@^1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -1770,6 +1860,11 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -1824,6 +1919,11 @@ figures@^1.4.0:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1909,6 +2009,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-exists-cached@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
@@ -1922,6 +2027,13 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1942,6 +2054,20 @@ function-loop@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/function-loop/-/function-loop-1.0.2.tgz#16b93dd757845eacfeca1a8061a6a65c106e0cb2"
   integrity sha512-Iw4MzMfS3udk/rqxTiDDCllhGwlOrsr50zViTOO/W6lS/9y6B1J0BD2VZzrnWUYBJsl3aeqjgR5v7bWWhZSYbA==
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2000,6 +2126,11 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -2130,6 +2261,11 @@ has-tostringtag@^1.0.0:
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has@^1.0.0, has@^1.0.3:
   version "1.0.3"
@@ -2264,7 +2400,7 @@ hyperstream@^1.2.2:
     trumpet "^1.6.4"
     utf8-stream "~0.0.0"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -2314,7 +2450,7 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
-ini@^1.3.4, ini@^1.3.5:
+ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -2955,6 +3091,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -2972,7 +3113,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@~0.0.8:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~0.0.8:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -2984,7 +3125,15 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
-mkdirp-classic@^0.5.2:
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
@@ -2996,7 +3145,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -3042,6 +3191,11 @@ ms@^2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 nested-error-stacks@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
@@ -3051,6 +3205,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-abi@^3.3.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.5.0.tgz#26e8b7b251c3260a5ac5ba5aef3b4345a0229248"
+  integrity sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==
+  dependencies:
+    semver "^7.3.5"
 
 node-gyp-build@^4.2.0:
   version "4.3.0"
@@ -3094,6 +3255,16 @@ npm-conf@^1.1.3:
   dependencies:
     config-chain "^1.1.11"
     pify "^3.0.0"
+
+npmlog@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3444,6 +3615,25 @@ plur@^1.0.0:
   resolved "https://registry.yarnpkg.com/plur/-/plur-1.0.0.tgz#db85c6814f5e5e5a3b49efc28d604fec62975156"
   integrity sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=
 
+prebuild-install@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.0.0.tgz#3c5ce3902f1cb9d6de5ae94ca53575e4af0c1574"
+  integrity sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
@@ -3567,6 +3757,16 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 re-emitter@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/re-emitter/-/re-emitter-1.1.3.tgz#fa9e319ffdeeeb35b27296ef0f3d374dac2f52a7"
@@ -3643,7 +3843,7 @@ readable-stream@2.2.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -3656,7 +3856,7 @@ readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@~2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3883,7 +4083,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
+semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -3902,7 +4102,7 @@ server-destroy@^1.0.1:
   resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
   integrity sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -3981,6 +4181,15 @@ simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.0.tgz#73fa628278d21de83dadd5512d2cc1f4872bd675"
+  integrity sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -4212,6 +4421,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -4228,15 +4446,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string.prototype.trim@^1.2.4:
   version "1.2.5"
@@ -4321,6 +4530,11 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 subarg@^1.0.0:
   version "1.0.0"
@@ -4517,6 +4731,39 @@ tape@^5.2.2:
     resumer "^0.0.0"
     string.prototype.trim "^1.2.4"
     through "^2.3.8"
+
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 tcompare@^3.0.0:
   version "3.0.5"
@@ -4928,6 +5175,13 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+  dependencies:
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## What's the problem you solved?

Not having a way to persist an Earthstar server to SQLite.

## What solution are you recommending?

I've added a node-only storage driver which uses `better-sqlite3` under the hood. It is a modified port of the original SQLite driver from Earthstar v1. 

- The type of the content column has been changed to `BLOB`, and the driver handles the transforming of `string` to `UInt8Array` and vice versa.
- This modified version adds a SQLite index for `localIndex` that is not yet being used.

I also had to modify test scenarios so that each storage driver has a `builtinConfigKeys` property, as the SQLite one has ones that are added upon instantiation (`schemaVersion`, `workspace`), which was breaking tests which checked the presence or absence of certain config keys.

I've also updated `peer-client-server.node.test.ts` to use test scenarios instead of a hardcoded set, as the SQLite driver takes more than just a workspace address in its constructor.