### PR TITLE
pin noble-ed25519 version from raw.github so it's stable

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -8,7 +8,7 @@ export * as sha256_uint8array from "https://esm.sh/sha256-uint8array@0.10.3";
 export { Superbus } from "./src/superbus/superbus.ts";
 export { Simplebus } from "./src/superbus/simplebus.ts";
 export { SuperbusMap } from "./src/superbus_map/superbus_map.ts";
-export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/main/mod.ts";
+export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/6e05e960522e6def6974769d5bff032eaed68685/mod.ts";
 export { Lock } from "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts";
 export { isDeno, isNode } from "https://deno.land/x/which_runtime@0.2.0/mod.ts";
 

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -36,7 +36,7 @@ await build({
       name: "chloride",
       version: "2.4.1",
     },
-    "https://raw.githubusercontent.com/sgwilym/noble-ed25519/main/mod.ts": {
+    "https://raw.githubusercontent.com/sgwilym/noble-ed25519/6e05e960522e6def6974769d5bff032eaed68685/mod.ts": {
       name: "@noble/ed25519",
       version: "1.4.0",
     },


### PR DESCRIPTION
## What's the problem you solved?

We were importing from an unversioned URL: https://raw.githubusercontent.com/sgwilym/noble-ed25519/main/mod.ts

This could cause headaches later if we push another commit to that repo.

## What solution are you recommending?

Import from the specific commit we want: https://raw.githubusercontent.com/sgwilym/noble-ed25519/6e05e960522e6def6974769d5bff032eaed68685/mod.ts