### PR TITLE
Add deno.json config for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ coverage: test-coverage show-coverage
 
 npm:
 	deno run --allow-all scripts/build_npm.ts $(VERSION)
-
-fmt:
-	deno fmt --options-indent-width=4 --options-line-width=100 src/ scripts/
 	
 bundle:
 	deno bundle --no-check=remote ./mod.ts ./earthstar.bundle.js

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Stone Soup - Earthstar v2
 
-This is a re-implementation of [Earthstar](https://github.com/earthstar-project/earthstar), maintaining compatability with the data format (see the specification) but changing the Typescript API and the networking protocol.
+This is a re-implementation of [Earthstar](https://github.com/earthstar-project/earthstar),
+maintaining compatability with the data format (see the specification) but changing the Typescript
+API and the networking protocol.
 
 ## Usage
 
 To use in Deno, add the following:
 
-```ts
+````ts
 import * as Earthstar from "https://setthisup.com/earthstar/mod.ts"
 ```;
 
@@ -18,36 +20,45 @@ And then import in your code:
 
 ```ts
 import * as Earthstar from "stone-soup";
-```
+````
 
 ### Platform-specific drivers
 
-There are two parts of stone-soup which are swappable to support different platforms or backends: `ICryptoDriver` and `IStorageDriverAsync`.  Everything else should work on all platforms.
+There are two parts of stone-soup which are swappable to support different platforms or backends:
+`ICryptoDriver` and `IStorageDriverAsync`. Everything else should work on all platforms.
 
 Crypto drivers:
-* `CryptoDriverChloride` - only in browser, Node
-* `CryptoDriverNode` - only in Node
-* `CryptoDriverNoble` - universal
+
+- `CryptoDriverChloride` - only in browser, Node
+- `CryptoDriverNode` - only in Node
+- `CryptoDriverNoble` - universal
 
 Storage drivers:
-* `StorageDriverAsyncMemory` - univeral
-* `StorageDriverLocalStorage` - browser 
-* `StorageDriverIndexedDB` - browser
-* `StorageDriverSqlite` - Node, Deno (⏳ coming soon)
 
-Users of this library have to decide which of these drivers to import and use in their app. Hopefully your app is using some build system that does tree-shaking and will discard the unused drivers.
+- `StorageDriverAsyncMemory` - univeral
+- `StorageDriverLocalStorage` - browser
+- `StorageDriverIndexedDB` - browser
+- `StorageDriverSqlite` - Node, Deno (⏳ coming soon)
+
+Users of this library have to decide which of these drivers to import and use in their app.
+Hopefully your app is using some build system that does tree-shaking and will discard the unused
+drivers.
 
 ## Development
 
 ### Setup
 
-You will need Deno installed. [Instructions for installation can be found here](https://deno.land/#installation). You may also want type-checking and linting from Deno for your IDE, which you can get with extensions [like this one for VSCode](https://deno.land/manual@v1.17.2/vscode_deno).
+You will need Deno installed.
+[Instructions for installation can be found here](https://deno.land/#installation). You may also
+want type-checking and linting from Deno for your IDE, which you can get with extensions
+[like this one for VSCode](https://deno.land/manual@v1.17.2/vscode_deno).
 
 To check that you've got everything set up correctly:
 
 `make example`
 
-This will run the example script at `example-app.ts`, and you will see a lot of colourful log messages from the app.
+This will run the example script at `example-app.ts`, and you will see a lot of colourful log
+messages from the app.
 
 ### Scripts
 
@@ -56,7 +67,8 @@ Scripts are run with the `make` command.
 - `make test` - Run all tests
 - `make test-watch` - Run all tests in watch mode
 - `make fmt` - Format all code in the codebase
-- `make npm` - Create a NPM package in `npm` and run tests against it (requires Node v14 or v16 to be installed).
+- `make npm` - Create a NPM package in `npm` and run tests against it (requires Node v14 or v16 to
+  be installed).
 - `make bundle` - Create a bundled browser script at `earthstar.bundle.js`
 - `make depchart` - Regenerate the dependency chart images
 - `make coverage` - Generate code test coverage statistics
@@ -65,34 +77,45 @@ Scripts are run with the `make` command.
 ### Orientation
 
 - The entry for the package can be found at `mod.ts`.
-- Most external dependencies can be found in `deps.ts`. All other files import external dependencies from this file.
+- Most external dependencies can be found in `deps.ts`. All other files import external dependencies
+  from this file.
 - Script definitions can be found in `Makefile`.
 - Tests are all in `src/test/`
 - The script for building the NPM package can be found in `scripts/build_npm.ts`
 
 ### Uint8Arrays and Buffers
 
-We use Uint8Arrays throughout the code to maximize platform support. Some of the node-specific drivers use Buffers internally but the Buffers are converted to Uint8Arrays before leaving those drivers.
+We use Uint8Arrays throughout the code to maximize platform support. Some of the node-specific
+drivers use Buffers internally but the Buffers are converted to Uint8Arrays before leaving those
+drivers.
 
-For convenience, variables that hold Uint8Arrays are called "bytes", like `bytesToHash` instead of `uint8ArrayToHash`.
+For convenience, variables that hold Uint8Arrays are called "bytes", like `bytesToHash` instead of
+`uint8ArrayToHash`.
 
-`util/bytes.ts` has a bunch of helper code to do common operations on Uint8Arrays and to convert them back and forth to strings and to Buffers.
+`util/bytes.ts` has a bunch of helper code to do common operations on Uint8Arrays and to convert
+them back and forth to strings and to Buffers.
 
 ### Platform-specific tests
 
-Drivers are tested against the runtimes they're intended for. When tests are run, they pull the correct scenarios from 'src/test/test-scenarios.ts', where the current runtime is inferred during runtime.
+Drivers are tested against the runtimes they're intended for. When tests are run, they pull the
+correct scenarios from 'src/test/test-scenarios.ts', where the current runtime is inferred during
+runtime.
 
 ### Classes
 
-The `IStorageAsync` is the main star of the show.  Classes to the right are used internally for its implementation.  Classes to the left stack on top of an `IStorageAsync` to do extra things to it (subscribe to changes, cache data, etc).
+The `IStorageAsync` is the main star of the show. Classes to the right are used internally for its
+implementation. Classes to the left stack on top of an `IStorageAsync` to do extra things to it
+(subscribe to changes, cache data, etc).
 
 Each `IStorageAsync` holds the Docs for one Workspace.
 
 ![](classes.png)
 
-Names starting with `I` are interfaces; there are one or multiple actual classes that implement those interfaces.
+Names starting with `I` are interfaces; there are one or multiple actual classes that implement
+those interfaces.
 
-The orange classes are "drivers" which have multiple implementations to choose from, for different platforms (node, browser, etc).
+The orange classes are "drivers" which have multiple implementations to choose from, for different
+platforms (node, browser, etc).
 
 Blue arrows show which functions call each other.
 
@@ -114,35 +137,38 @@ Run `yarn depchart` to regenerate this. You'll need graphviz installed.
 
 ### Documentation
 
-We use JSDoc for user documentation. You can view docs for the whole codebase at https://doc.deno.land/https://deno.land/x/stone_soup@v8.0.0/mod.ts, or by running the following from the root of the project:
+We use JSDoc for user documentation. You can view docs for the whole codebase at
+https://doc.deno.land/https://deno.land/x/stone_soup@v8.0.0/mod.ts, or by running the following from
+the root of the project:
 
 ```
 deno doc mod.ts
 ```
 
-JSDocs are intended for end-users of the library. Comments for contributors working with the codebase — e.g. notes on how something is implemented — are better as standard JS comments.
+JSDocs are intended for end-users of the library. Comments for contributors working with the
+codebase — e.g. notes on how something is implemented — are better as standard JS comments.
 
 If possible, use a single line for the JSDoc. Example:
 
 ```ts
 /** Does something great */
 export function doSomething() {
-  // ...
+    // ...
 }
 ```
 
-You can use markdown inside of JSDoc block. While markdown supports HTML tags, it is forbidden in JSDoc blocks.
+You can use markdown inside of JSDoc block. While markdown supports HTML tags, it is forbidden in
+JSDoc blocks.
 
-Code string literals should be braced with the back-tick (\`) instead of quotes.
-For example:
+Code string literals should be braced with the back-tick (\`) instead of quotes. For example:
 
 ```ts
 /** Import something from the `earthstar` module. */
 ```
 
 It's not necessary to document function arguments unless an extra explanation is warranted.
-Therefore `@param` should generally not be used. If `@param` is used, it should
-not include the `type` as TypeScript is already strongly typed.
+Therefore `@param` should generally not be used. If `@param` is used, it should not include the
+`type` as TypeScript is already strongly typed.
 
 ```ts
 /**
@@ -153,24 +179,26 @@ not include the `type` as TypeScript is already strongly typed.
 
 Code examples should utilize markdown format, like so:
 
-```ts
+````ts
 /** A straight forward comment and an example:
  * ```ts
  * import { Crypto } from "stone-soup";
  * const keypair = Crypto.generateAuthorKeypair("suzy");
  * ```
  */
-```
+````
 
-Code examples should not contain additional comments and must not be indented.
-It is already inside a comment. If it needs further comments it is not a good
-example.
+Code examples should not contain additional comments and must not be indented. It is already inside
+a comment. If it needs further comments it is not a good example.
 
-Exported functions should use the `function` keyword, and not be defined as inline functions assigned to variables. The main reason for this being that they are then correctly categorised as functions.
+Exported functions should use the `function` keyword, and not be defined as inline functions
+assigned to variables. The main reason for this being that they are then correctly categorised as
+functions.
 
 ### Publishing to NPM
 
-1. Run `make VERSION="version.number.here" npm`, where `version.number.here` is the desired version number for the package.
+1. Run `make VERSION="version.number.here" npm`, where `version.number.here` is the desired version
+   number for the package.
 2. `cd npm`
 3. `npm publish`
 
@@ -183,49 +211,70 @@ Think of this as `IStorageNiceAPIFullOfComplexity` and `IStorageSimpleLowLevelDr
 I want to make it easier to add new kinds of storage so I'm splitting IStorage into two parts:
 
 The Storage does:
-* the complex annoying stuff we only want to write once
-* `set():` sign and add a document
-* `ingest():` validate and accept a document from the outside
-* user-friendly helper functions, getters, setters
-* an event bus that other things can subscribe to, like QueryFollowers
+
+- the complex annoying stuff we only want to write once
+- `set():` sign and add a document
+- `ingest():` validate and accept a document from the outside
+- user-friendly helper functions, getters, setters
+- an event bus that other things can subscribe to, like QueryFollowers
 
 The StorageDriver does:
-* simple stuff, so we can make lots of drivers
-* query for documents (this is actually pretty complicated)
-* maintain indexes for querying (hopefully provided by the underlying storage technology)
-* simple upsert of a document with no smartness
 
-Possibly even you can have multiple Storages for one Driver, for example when you're using multiple tabs with indexedDb or localStorage.
+- simple stuff, so we can make lots of drivers
+- query for documents (this is actually pretty complicated)
+- maintain indexes for querying (hopefully provided by the underlying storage technology)
+- simple upsert of a document with no smartness
+
+Possibly even you can have multiple Storages for one Driver, for example when you're using multiple
+tabs with indexedDb or localStorage.
 
 ### "Reliable indexing / streaming"
 
-This shows an implementation of the "reliable indexing" idea discussed in [this issue](https://github.com/earthstar-project/earthstar/issues/66).
+This shows an implementation of the "reliable indexing" idea discussed in
+[this issue](https://github.com/earthstar-project/earthstar/issues/66).
 
 #### The problem
 
-We have livestreaming now, over the network and also to local subscribers, all based on `onWrite` events.
+We have livestreaming now, over the network and also to local subscribers, all based on `onWrite`
+events.
 
-If you miss some events, you can't recover -- you have to do a full batch download of every document.
+If you miss some events, you can't recover -- you have to do a full batch download of every
+document.
 
-Events also don't tell you what was overwritten, which you might need to know to update a Layer or index.
+Events also don't tell you what was overwritten, which you might need to know to update a Layer or
+index.
 
 #### The solution: `localIndex`
 
-Each Storage keeps track of the order that it receives documents, and assignes each doc a `localIndex` value which starts at 1 and increments from there with every newly written doc.
+Each Storage keeps track of the order that it receives documents, and assignes each doc a
+`localIndex` value which starts at 1 and increments from there with every newly written doc.
 
-This puts the documents in a nice stable linear order that can be used to reliably stream, and resume streaming, from the Storage.
+This puts the documents in a nice stable linear order that can be used to reliably stream, and
+resume streaming, from the Storage.
 
-When we get a new version of a document, it gets a new `localIndex` and goes at the end of the sequence, and the old version vanishes, leaving a gap in the sequence.  It's ok that there are gaps.
+When we get a new version of a document, it gets a new `localIndex` and goes at the end of the
+sequence, and the old version vanishes, leaving a gap in the sequence. It's ok that there are gaps.
 
-The `localIndex` is particular to a certain IStorage.  It's kept in the `Doc` object but it's not really part of it; it's not included in the signature.  It's this IStorage's metadata about that document.  When syncing, it's sent as one of the "extra fields" [(newly added to the specification)](https://earthstar-docs.netlify.app/docs/reference/earthstar-specification/#extra-fields-for-syncing), observed by the receiving peer, then discarded and overwritten with the receiving peer's own latest `localIndex` number.
+The `localIndex` is particular to a certain IStorage. It's kept in the `Doc` object but it's not
+really part of it; it's not included in the signature. It's this IStorage's metadata about that
+document. When syncing, it's sent as one of the "extra fields"
+[(newly added to the specification)](https://earthstar-docs.netlify.app/docs/reference/earthstar-specification/#extra-fields-for-syncing),
+observed by the receiving peer, then discarded and overwritten with the receiving peer's own latest
+`localIndex` number.
 
 #### Use cases
 
 1. Streaming sync between peers, which can be interrupted and resumed
-1. Layers and indexes that use a QueryFollower to subscribe to changes in a Storage.  These might store their indexes in localStorage, for example, and would therefore want to resume indexing instead of starting over from scratch.
+1. Layers and indexes that use a QueryFollower to subscribe to changes in a Storage. These might
+   store their indexes in localStorage, for example, and would therefore want to resume indexing
+   instead of starting over from scratch.
 1. React components that need to know when to re-render
 
-For use cases where the listener will never have any downtime, they don't really need to be able to resume, they can just listen for events from the Storage instead and it may be more efficient.  For example a React component could listen for events about a particular document instead of making a whole QueryFollower that has to go through every single change to find changes to that particular document.
+For use cases where the listener will never have any downtime, they don't really need to be able to
+resume, they can just listen for events from the Storage instead and it may be more efficient. For
+example a React component could listen for events about a particular document instead of making a
+whole QueryFollower that has to go through every single change to find changes to that particular
+document.
 
 #### Properties of the `localIndex` sequence
 
@@ -235,26 +284,51 @@ The docs, sorted by `localIndex` on a particular peer, have these properties:
 
 1. The docs are in a stable order that does not change, except:
 1. Newly added or changed docs go at the end, increasing the highest `localIndex` by 1.
-1. When a doc is updated (same author and same path, but newer timestamp), we discard the old version.  So we leave a gap in the sequence where the old verison used to be, and the new version goes on the end of the sequence.
-1. The first doc has a `localIndex` of zero, unless it was later changed, in which case there will be a gap at zero.
+1. When a doc is updated (same author and same path, but newer timestamp), we discard the old
+   version. So we leave a gap in the sequence where the old verison used to be, and the new version
+   goes on the end of the sequence.
+1. The first doc has a `localIndex` of zero, unless it was later changed, in which case there will
+   be a gap at zero.
 
-Why do all this?  The goal is to be able to catch up to changes since the last time we looked at a Storage.  We can do that by remembering the highest `localIndex` we saw last time, and now getting all the docs later than that in the sequence.  We always read this sequence from old to new (in increasing order of `localIndex`.
+Why do all this? The goal is to be able to catch up to changes since the last time we looked at a
+Storage. We can do that by remembering the highest `localIndex` we saw last time, and now getting
+all the docs later than that in the sequence. We always read this sequence from old to new (in
+increasing order of `localIndex`.
 
 There are not really any other nice properties about this sequence:
 
 **Downsides**
 
-1. The `localIndex` order is not sorted by `path`, `timestamp`, `author`, or any other useful property.  The order is jumbled because docs can be received in any order during a sync, perhaps with multiple other peers simultaneously, perhaps some using Sync Filters to only get some docs...
+1. The `localIndex` order is not sorted by `path`, `timestamp`, `author`, or any other useful
+   property. The order is jumbled because docs can be received in any order during a sync, perhaps
+   with multiple other peers simultaneously, perhaps some using Sync Filters to only get some
+   docs...
 1. The order is different on every peer (that's why it's "local").
-1. The history docs for a certain path will be in a jumbled order in the `localIndex` sequence.  The Latest doc for a path can be before or after the other history docs.  User of QueryFollowers will need some bookeeping to remember which version is the Latest for each path, if they care (e.g. if it's being used as an index and not just a sync mechanism between peers).
-1. When a doc is modified and the old one is deleted, leaving a gap, you do not get notified about the gap.  There is no pointer back to the gap, or anything.  Users of QueryFollowers are expected to have some kind of index so they can notice that the new doc overwrites the old one, and delete the old one.
-1. When an ephemeral doc expires, it leaves a gap in the sequence but nothing is added to the end of the sequence.  Users of QueryFollowers are expected to pay attention to expiration dates and delete ephemeral docs themselves.  We may also add an event on the Storage when a doc expires, but you could miss this event if you were not listening at that moment, so you'll still have to check for your own expired docs from time to time.
-1. QueryFollowers should always progress in the direction of increasing `localIndex`.  (They can start at 0, or the latest number, or anywhere in between).  This makes it simple to keep track of where to resume next time.  However this means we always process the oldest-received docs first, but the user probably cares more about the recently-received docs.
-    * It would be possible with fancier bookeeping to make QueryFollowers that track which intervals of the sequence they've visited, so they can work from newest-to-oldest.  But sometimes the oldest-received docs are the most important (like usernames)...
+1. The history docs for a certain path will be in a jumbled order in the `localIndex` sequence. The
+   Latest doc for a path can be before or after the other history docs. User of QueryFollowers will
+   need some bookeeping to remember which version is the Latest for each path, if they care (e.g. if
+   it's being used as an index and not just a sync mechanism between peers).
+1. When a doc is modified and the old one is deleted, leaving a gap, you do not get notified about
+   the gap. There is no pointer back to the gap, or anything. Users of QueryFollowers are expected
+   to have some kind of index so they can notice that the new doc overwrites the old one, and delete
+   the old one.
+1. When an ephemeral doc expires, it leaves a gap in the sequence but nothing is added to the end of
+   the sequence. Users of QueryFollowers are expected to pay attention to expiration dates and
+   delete ephemeral docs themselves. We may also add an event on the Storage when a doc expires, but
+   you could miss this event if you were not listening at that moment, so you'll still have to check
+   for your own expired docs from time to time.
+1. QueryFollowers should always progress in the direction of increasing `localIndex`. (They can
+   start at 0, or the latest number, or anywhere in between). This makes it simple to keep track of
+   where to resume next time. However this means we always process the oldest-received docs first,
+   but the user probably cares more about the recently-received docs.
+   - It would be possible with fancier bookeeping to make QueryFollowers that track which intervals
+     of the sequence they've visited, so they can work from newest-to-oldest. But sometimes the
+     oldest-received docs are the most important (like usernames)...
 
 #### Querying by `localIndex`
 
-This lets you easily resume where you left off.  You can get batches of N docs at a time if you want, using the `limit` option.
+This lets you easily resume where you left off. You can get batches of N docs at a time if you want,
+using the `limit` option.
 
 ```ts
 storage.getDocsSinceLocalIndex(
@@ -262,27 +336,36 @@ storage.getDocsSinceLocalIndex(
     limit?: number): Doc[];
 ```
 
-This is also how you tell a QueryFollower where to start in the sequence.  QueryFollowers ignore the `limit` property though.
+This is also how you tell a QueryFollower where to start in the sequence. QueryFollowers ignore the
+`limit` property though.
 
 (You can also still look up documents by path in the usual old way.)
 
 ### QueryFollowers: Reliable streaming locally, to subscribers or indexes
 
-The old `onWrite` events are gone.  Now, there's now a new way to subscribe to a Storage: with a `QueryFollower`.  A query follower is like a pointer that moves along the sequence of documents, in order by `localIndex`, running a callback on each one, if it matches the given query.
+The old `onWrite` events are gone. Now, there's now a new way to subscribe to a Storage: with a
+`QueryFollower`. A query follower is like a pointer that moves along the sequence of documents, in
+order by `localIndex`, running a callback on each one, if it matches the given query.
 
 This is a Kafka or Kappa-db style architecture.
 
-You could use this to build an index or Layer that incrementally digests the content of an IStorage without ever missing anything, even if it only runs occasionally.  It just resumes from the last `localIndex` it saw, and proceeds from there.
+You could use this to build an index or Layer that incrementally digests the content of an IStorage
+without ever missing anything, even if it only runs occasionally. It just resumes from the last
+`localIndex` it saw, and proceeds from there.
 
-Currently QueryFollowers are always blocking -- they hold up the entire Storage until they catch up, and when a new doc is ingested everything waits until the QueryFollowers have finished running.
+Currently QueryFollowers are always blocking -- they hold up the entire Storage until they catch up,
+and when a new doc is ingested everything waits until the QueryFollowers have finished running.
 
-A QueryFollower has one async callback that it runs on each doc in sequence.  It never allows that callback to overlap with itself, e.g. it waits to finish one doc before moving along to the next.
+A QueryFollower has one async callback that it runs on each doc in sequence. It never allows that
+callback to overlap with itself, e.g. it waits to finish one doc before moving along to the next.
 
-An IStorage may have many QueryFollowers.  They will run in parallel with each other, while the IStorage waits for them all to finish.
+An IStorage may have many QueryFollowers. They will run in parallel with each other, while the
+IStorage waits for them all to finish.
 
 ### Starting query followers at the beginning or the end
 
-You can start a QueryFollower anywhere in the sequence: at the beginning (good for indexes and Layers), or at the current most recent document (good for live syncing new changes).
+You can start a QueryFollower anywhere in the sequence: at the beginning (good for indexes and
+Layers), or at the current most recent document (good for live syncing new changes).
 
 You do this by setting the `startAt: {localIndex: 123}` property of the query.
 
@@ -290,33 +373,50 @@ You do this by setting the `startAt: {localIndex: 123}` property of the query.
 
 (Not implemented in this code yet)
 
-When we send docs over the network we will send the `localIndex` to help the other side track where they are in our own sequence.  The other side will then discard the property and put their own `localIndex` on the document when they store it.
+When we send docs over the network we will send the `localIndex` to help the other side track where
+they are in our own sequence. The other side will then discard the property and put their own
+`localIndex` on the document when they store it.
 
-Peers will remember, for each other peer, which is the latest `localIndex` they've seen from that peer, so they can resume syncing from there.
+Peers will remember, for each other peer, which is the latest `localIndex` they've seen from that
+peer, so they can resume syncing from there.
 
-This is similar to how append-only logs are synced in Scuttlebutt and Hyper, except our logs have gaps.
+This is similar to how append-only logs are synced in Scuttlebutt and Hyper, except our logs have
+gaps.
 
 ### Slightly different querying
 
-Querying has been made more organized -- see the Query type in `types.ts`.  It looks a bit more like an SQL query but the pieces are written in the order they actually happen, so it's easier to understand.
+Querying has been made more organized -- see the Query type in `types.ts`. It looks a bit more like
+an SQL query but the pieces are written in the order they actually happen, so it's easier to
+understand.
 
 The order is:
-* history (all or latest only)
-* orderBy
-* startAt (continue from a certain point)
-* filter - the same options, timestamp, pathStartswith, etc etc
-* limit
 
-Also, the `cleanUpQuery` function is fancier and will also figure out if the query will match `all`, `some`, or `nothing` documents.  This helps with optimizations elsewhere.
+- history (all or latest only)
+- orderBy
+- startAt (continue from a certain point)
+- filter - the same options, timestamp, pathStartswith, etc etc
+- limit
+
+Also, the `cleanUpQuery` function is fancier and will also figure out if the query will match `all`,
+`some`, or `nothing` documents. This helps with optimizations elsewhere.
 
 ## Problems left to solve
 
-* Ephemeral documents disappear without leaving a trace, do we need events for that?
-* An IStorage might significantly change or start over, by deleting most of its local documents and choosing a different sync query.  Then we'd need to tell subscribers and peers that we're effectively a different IStorage now.
-  * localIndex could be a tuple `[generation, localIndex]` where generation is an integer that increments on each big change like that
-  * or give each IStorage a UUID which gets randomly changed when big changes happen.  This would be helpful for other reasons too (to prevent echoing back documents to the storage that just gave them back to us, we need to track who gave them to us)
-* Syncing by `localIndex` doesn't work very well when you also have a sync query, because you have to scan the entire sequence to find the couple of docs you care about.  We probably still want another way of efficient syncing that goes in path order and uses hashing in some clever way, sort of like a Merkle tree but not.
+- Ephemeral documents disappear without leaving a trace, do we need events for that?
+- An IStorage might significantly change or start over, by deleting most of its local documents and
+  choosing a different sync query. Then we'd need to tell subscribers and peers that we're
+  effectively a different IStorage now.
+  - localIndex could be a tuple `[generation, localIndex]` where generation is an integer that
+    increments on each big change like that
+  - or give each IStorage a UUID which gets randomly changed when big changes happen. This would be
+    helpful for other reasons too (to prevent echoing back documents to the storage that just gave
+    them back to us, we need to track who gave them to us)
+- Syncing by `localIndex` doesn't work very well when you also have a sync query, because you have
+  to scan the entire sequence to find the couple of docs you care about. We probably still want
+  another way of efficient syncing that goes in path order and uses hashing in some clever way, sort
+  of like a Merkle tree but not.
 
 ## Other small improvements
 
-* The `Document` type is now named `Doc` to avoid collision with an existing built-in Typescript type
+- The `Document` type is now named `Doc` to avoid collision with an existing built-in Typescript
+  type

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,11 @@
+{
+    "fmt": {
+        "files": {
+            "exclude": ["npm", ".git", "earthstar.bundle.js", ".nova"]
+        },
+        "options": {
+            "indentWidth": 4,
+            "lineWidth": 100
+        }
+    }
+}

--- a/example-app.ts
+++ b/example-app.ts
@@ -1,12 +1,21 @@
-import { isErr, sleep, FormatValidatorEs4, StorageDriverAsyncMemory, StorageAsync, Crypto, AuthorKeypair, QueryFollower, Peer,  Logger,
+import {
+    AuthorKeypair,
+    Crypto,
+    FormatValidatorEs4,
+    isErr,
+    LiveQueryEvent,
+    Logger,
     LogLevel,
+    Peer,
+    QueryFollower,
     setDefaultLogLevel,
-    setLogLevel, LiveQueryEvent } from "./mod.ts";
+    setLogLevel,
+    sleep,
+    StorageAsync,
+    StorageDriverAsyncMemory,
+} from "./mod.ts";
 
 //--------------------------------------------------
-
-
-
 
 let loggerMain = new Logger("main", "whiteBright");
 let loggerBusEvents = new Logger("main storage bus events", "white");

--- a/src/query-follower/query-follower-types.ts
+++ b/src/query-follower/query-follower-types.ts
@@ -13,11 +13,11 @@ import { IStorageAsync, LiveQueryEvent } from "../storage/storage-types.ts";
  * - `error` — an unexpected error happened, maybe in your bus subscription handler.
  */
 export type QueryFollowerState =
-  | "new"
-  | "catching-up"
-  | "live"
-  | "closed"
-  | "error";
+    | "new"
+    | "catching-up"
+    | "live"
+    | "closed"
+    | "error";
 
 /**
  * Subscribe to the ongoing results of a query, optionally including old existing docs.
@@ -33,40 +33,40 @@ export type QueryFollowerState =
  * ```
  */
 export interface IQueryFollower {
-  storage: IStorageAsync;
-  /**
-   * The query being followed. Has some limitations:
-   * - `historyMode` must be `all`
-   * - `orderBy` must be `localIndex ASC`
-   * - limit can NOT be set.
-   */
-  query: Query;
+    storage: IStorageAsync;
+    /**
+     * The query being followed. Has some limitations:
+     * - `historyMode` must be `all`
+     * - `orderBy` must be `localIndex ASC`
+     * - limit can NOT be set.
+     */
+    query: Query;
 
-  /** Use this to subcribe to events with a callback, which will be called blockingly (one event at a time, one callback at a time).
-   *
-   * For now it's tricky to close a query follower from inside its own event handler; you have to do it using setTimeout or you'll deadlock on the bus's lock.
-   * ```ts
-   * qf.bus.on(await (event) => {
-   *   setTimeout(() => qf.close(), 0);
-   * });
-   * ```
-   * (because you can't send an event from inside an event handler)
-   */
-  bus: Simplebus<LiveQueryEvent>;
+    /** Use this to subcribe to events with a callback, which will be called blockingly (one event at a time, one callback at a time).
+     *
+     * For now it's tricky to close a query follower from inside its own event handler; you have to do it using setTimeout or you'll deadlock on the bus's lock.
+     * ```ts
+     * qf.bus.on(await (event) => {
+     *   setTimeout(() => qf.close(), 0);
+     * });
+     * ```
+     * (because you can't send an event from inside an event handler)
+     */
+    bus: Simplebus<LiveQueryEvent>;
 
-  /** Returns the follower's state, which can be in two modes:
-   *   1. catching up with the backlog
-   *   2. caught up; processing new events as they happen.
-   * When the query follower is in catching-up mode, it runs independently on its own schedule.  When it's in live mode, it processes each doc  as it's written, blockingly, which means it provides backpressure all the way back up to whatever is trying to ingest() docs into the storage.
-   * There is not currently an easy way to know when a query follower has caught up and switched to live mode, except to listen for the 'idle' event on its bus.
-   */
-  state(): QueryFollowerState;
+    /** Returns the follower's state, which can be in two modes:
+     *   1. catching up with the backlog
+     *   2. caught up; processing new events as they happen.
+     * When the query follower is in catching-up mode, it runs independently on its own schedule.  When it's in live mode, it processes each doc  as it's written, blockingly, which means it provides backpressure all the way back up to whatever is trying to ingest() docs into the storage.
+     * There is not currently an easy way to know when a query follower has caught up and switched to live mode, except to listen for the 'idle' event on its bus.
+     */
+    state(): QueryFollowerState;
 
-  /** Begins the process of catching up with existing documents (if needed), then switches to live mode. */
-  hatch(): Promise<void>;
+    /** Begins the process of catching up with existing documents (if needed), then switches to live mode. */
+    hatch(): Promise<void>;
 
-  /** Permanently shut down the QueryFollower, unhooking from the storage and stopping the processing of events. Automatically called when the followed storage closes. */
-  // Triggered when the storage closes
-  // Can also be called manually if you just want to destroy this queryFollower.
-  close(): Promise<void>;
+    /** Permanently shut down the QueryFollower, unhooking from the storage and stopping the processing of events. Automatically called when the followed storage closes. */
+    // Triggered when the storage closes
+    // Can also be called manually if you just want to destroy this queryFollower.
+    close(): Promise<void>;
 }

--- a/src/query-follower/query-follower.ts
+++ b/src/query-follower/query-follower.ts
@@ -4,26 +4,21 @@ import { Thunk } from "../storage/util-types.ts";
 import { Query } from "../query/query-types.ts";
 import { NotImplementedError, StorageIsClosedError } from "../util/errors.ts";
 import {
-  DocAlreadyExists,
-  IdleEvent,
-  IStorageAsync,
-  LiveQueryEvent,
-  QueryFollowerDidClose,
-  StorageBusChannel,
-  StorageEventDidClose,
-  StorageEventWillClose,
+    DocAlreadyExists,
+    IdleEvent,
+    IStorageAsync,
+    LiveQueryEvent,
+    QueryFollowerDidClose,
+    StorageBusChannel,
+    StorageEventDidClose,
+    StorageEventWillClose,
 } from "../storage/storage-types.ts";
 import { docMatchesFilter } from "../query/query.ts";
 import { IQueryFollower, QueryFollowerState } from "./query-follower-types.ts";
 
 //================================================================================
 
-import {
-  Logger,
-  LogLevel,
-  setDefaultLogLevel,
-  setLogLevel,
-} from "../util/log.ts";
+import { Logger, LogLevel, setDefaultLogLevel, setLogLevel } from "../util/log.ts";
 import { deepCopy, sleep } from "../util/misc.ts";
 let logger = new Logger("QueryFollower", "redBright");
 let loggerSub = new Logger("QueryFollowerSub", "red");
@@ -48,329 +43,329 @@ let J = JSON.stringify;
  * ```
  */
 export class QueryFollower implements IQueryFollower {
-  storage: IStorageAsync;
-  /**
-   * The query being followed. Has some limitations:
-   * - `historyMode` must be `all`
-   * - `orderBy` must be `localIndex ASC`
-   * - limit can NOT be set.
-   */
-  query: Query;
-  /** Use this to subcribe to events with a callback, which will be called blockingly (one event at a time, one callback at a time).
-   *
-   * For now it's tricky to close a query follower from inside its own event handler; you have to do it using setTimeout or you'll deadlock on the bus's lock.
-   * ```ts
-   * qf.bus.on(await (event) => {
-   *   setTimeout(() => qf.close(), 0);
-   * });
-   * ```
-   * (because you can't send an event from inside an event handler)
-   */
-  bus: Simplebus<LiveQueryEvent>;
-  _state: QueryFollowerState = "new";
-  _unsub: Thunk | null = null; // to unsub from storage events
+    storage: IStorageAsync;
+    /**
+     * The query being followed. Has some limitations:
+     * - `historyMode` must be `all`
+     * - `orderBy` must be `localIndex ASC`
+     * - limit can NOT be set.
+     */
+    query: Query;
+    /** Use this to subcribe to events with a callback, which will be called blockingly (one event at a time, one callback at a time).
+     *
+     * For now it's tricky to close a query follower from inside its own event handler; you have to do it using setTimeout or you'll deadlock on the bus's lock.
+     * ```ts
+     * qf.bus.on(await (event) => {
+     *   setTimeout(() => qf.close(), 0);
+     * });
+     * ```
+     * (because you can't send an event from inside an event handler)
+     */
+    bus: Simplebus<LiveQueryEvent>;
+    _state: QueryFollowerState = "new";
+    _unsub: Thunk | null = null; // to unsub from storage events
 
-  /**
-   * Create a new QueryFollower
-   * @param query - The query to be followed. Has some limitations: `historyMode` must be `all`; `orderBy` must be `localIndex ASC`; `limit` can *not* be set. The query's `startAfter` controls the behaviour of the follower: if not set, we begin with the next write event that occurs, and ignore existing documents; if `startAfter` is set to a `localIndex` value, we begin there. The usual case is to set `startAfter` to -1 to process all documents.
-   */
-  constructor(storage: IStorageAsync, query: Query) {
-    logger.debug("constructor");
-    this.storage = storage;
-    this.query = deepCopy(query); // we'll modify the query as we go, changing the startAfter
-    this.bus = new Simplebus<LiveQueryEvent>();
+    /**
+     * Create a new QueryFollower
+     * @param query - The query to be followed. Has some limitations: `historyMode` must be `all`; `orderBy` must be `localIndex ASC`; `limit` can *not* be set. The query's `startAfter` controls the behaviour of the follower: if not set, we begin with the next write event that occurs, and ignore existing documents; if `startAfter` is set to a `localIndex` value, we begin there. The usual case is to set `startAfter` to -1 to process all documents.
+     */
+    constructor(storage: IStorageAsync, query: Query) {
+        logger.debug("constructor");
+        this.storage = storage;
+        this.query = deepCopy(query); // we'll modify the query as we go, changing the startAfter
+        this.bus = new Simplebus<LiveQueryEvent>();
 
-    // enforce rules on supported queries
-    logger.debug("...enforcing rules on supported queries");
-    if (query.historyMode !== "all") {
-      throw new NotImplementedError(
-        `QueryFollower historyMode must be 'all'`,
-      );
-    }
-    if (query.orderBy !== "localIndex ASC") {
-      throw new NotImplementedError(
-        `QueryFollower orderBy must be 'localIndex ASC'`,
-      );
-    }
-    if (query.limit !== undefined) {
-      throw new NotImplementedError(
-        `QueryFollower must not have a limit`,
-      );
-    }
-  }
-
-  _expectState(states: QueryFollowerState[]) {
-    if (states.indexOf(this._state) === -1) {
-      throw new Error(
-        `QueryFollower expected state to be one of ${
-          J(states)
-        } but instead found ${this._state}`,
-      );
-    }
-  }
-
-  /** Returns the follower's state, which can be in two modes:
-   *   1. catching up with the backlog
-   *   2. caught up; processing new events as they happen.
-   * When the query follower is in catching-up mode, it runs independently on its own schedule.  When it's in live mode, it processes each doc  as it's written, blockingly, which means it provides backpressure all the way back up to whatever is trying to ingest() docs into the storage.
-   * There is not currently an easy way to know when a query follower has caught up and switched to live mode, except to listen for the 'idle' event on its bus.
-   */
-  state(): QueryFollowerState {
-    logger.debug("state() => " + this._state);
-    return this._state;
-  }
-
-  /** Begins the process of catching up with existing documents (if needed), then switches to live mode.
-   */
-  async hatch(): Promise<void> {
-    logger.debug("hatch...");
-
-    this._expectState(["new"]);
-
-    logger.debug("...hatch: calling _catchUp");
-    await this._catchUp();
-    this._expectState(["closed", "error", "live"]);
-    logger.debug("...hatch: done calling _catchUp");
-    logger.debug(`...hatch: state is "${this._state}"`);
-
-    logger.debug(`...hatch is done`);
-  }
-
-  async _catchUp(): Promise<void> {
-    // call this from state "new"
-    // pass through state "catching-up"
-    // end in state:
-    //  "live" is we finished catching up and started the live subscription to the storage
-    //  "closed" if storage became closed
-    //  "error" if something else happened, probably an error from the bus handler
-
-    logger.debug("_catchUp...");
-    this._expectState(["new"]);
-
-    let storage = this.storage;
-    let driver = this.storage.storageDriver;
-    let query = this.query;
-
-    if (query.startAfter === undefined) {
-      logger.debug(
-        `..._catchUp was not needed becaue startAfter is undefined, so we're going right to live mode.`,
-      );
-      this._state = "live";
-      // the moment we become live, we're idle
-      let idleEvent: IdleEvent = { kind: "idle" };
-      await this.bus.send(idleEvent);
-      this._subscribe();
-      return;
-    }
-
-    // catch up if needed
-    this._state = "catching-up";
-    logger.debug(`QueryFollower has a startAfter already; catching up.`);
-    while (true) {
-      let asOf1: number = -100; // before query
-      let asOf2: number = -100; // after query; before callbacks, doesn't really matter
-      let asOf3: number = -100; // after callbacks
-      let maxReturned: number = -100;
-      // do a query
-      try {
-        asOf1 = driver.getMaxLocalIndex();
-        logger.debug(
-          `...at ${asOf1}, started querying for existing docs`,
-        );
-        // TODO: catch up in smaller batches by setting a limit in the query
-        // TODO: check often to see if the queryfollower itself has been closed
-        let existingDocs = await storage.queryDocs(query);
-        for (let doc of existingDocs) {
-          maxReturned = Math.max(maxReturned, doc._localIndex ?? -1);
-        }
-        asOf2 = driver.getMaxLocalIndex();
-        logger.debug(
-          `...at ${asOf2}, got ${existingDocs.length} existing docs`,
-        );
-        logger.debug(`...sending docs to bus...`);
-        for (let doc of existingDocs) {
-          let event: DocAlreadyExists = {
-            kind: "existing",
-            maxLocalIndex: asOf2,
-            doc: doc, // TODO: should be the just-written doc, frozen, with updated extra properties like _localIndex
-          };
-          await this.bus.send(event);
-        }
-        asOf3 = driver.getMaxLocalIndex();
-        logger.debug(
-          `...at ${asOf3}, finished running ${existingDocs.length} callbacks for existing docs`,
-        );
-      } catch (err) {
-        if (err instanceof StorageIsClosedError) {
-          logger.debug(
-            `storage was closed while we were catching up, oh well.`,
-          );
-          this.close();
-        } else {
-          // TODO: what now?  are we stuck in 'error' state?
-          // should we close?
-          this._state = "error";
-          throw err;
-        }
-      }
-
-      // check for stopping conditions for query catch-up loop
-      let asOfSummary =
-        `( asOf: ${asOf1} [query] ${asOf2} [callbacks] ${asOf3}.  maxReturned: ${maxReturned} )`;
-      logger.debug(`...query and callback summary: ${asOfSummary}`);
-      if (asOf1 === asOf3) {
-        logger.debug(
-          `...asOf stayed at ${asOf1} so nothing new has happened since we did the query, so we can stop catching up now.`,
-        );
-        logger.debug(`...setting startAfter to localIndex: ${asOf1}`);
-        // no changes; we can stop catching up
-        // and let's set startAfter to continue where we just left off.
-        query.startAfter = { localIndex: asOf1 };
-        this._state = "live";
-        // the moment we become live, we're idle
-        let idleEvent: IdleEvent = { kind: "idle" };
-        await this.bus.send(idleEvent);
-        this._subscribe();
-        break;
-      } else {
-        // changes happened.
-        // wait a moment, then do another query to keep catching up.
-        logger.debug(
-          `...asOf went from ${asOf1} to ${asOf3} so changes happened since we did our query; gotta query again to get those changes.`,
-        );
-        logger.debug(
-          `...setting startAfter to localIndex: ${maxReturned} which is the max returned doc we saw.`,
-        );
-        query.startAfter = { localIndex: maxReturned };
-        await sleep(10);
-      }
-    } // end of while(true) loop
-
-    logger.debug(
-      `..._catchUp is done, we should now be live: '${this.state()}'`,
-    );
-    this._expectState(["live"]);
-  }
-
-  _subscribe() {
-    // if query did not specify a startAfter, we will start with the next
-    // ingest event that happens.
-
-    // we have just entered live mode, so we need to subscribe to new events.
-    // we'll return an unsubscribe function.
-
-    logger.debug("_subscribe...");
-    this._expectState(["live"]);
-
-    let driver = this.storage.storageDriver;
-    let query = this.query;
-
-    let queryFilter = query.filter || {};
-    let queryStartAfter = driver.getMaxLocalIndex();
-    if (
-      query.startAfter !== undefined &&
-      query.startAfter.localIndex !== undefined
-    ) {
-      queryStartAfter = query.startAfter.localIndex;
-    }
-    logger.debug(`QueryFollower is switching to subscription mode:`);
-    logger.debug(`...queryFilter: ${J(queryFilter)}`);
-    logger.debug(
-      `...start paying attention after local index ${queryStartAfter}.  subscribing...`,
-    );
-
-    this._unsub = this.storage.bus.on(
-      "*",
-      async (channel: StorageBusChannel | "*", data: any) => {
-        this._expectState(["live"]); // make sure the query follower itself has not been closed
-
-        loggerSub.debug(
-          `--- QueryFollower subscription: got an event on channel ${channel}`,
-        );
-        let event = data as LiveQueryEvent;
-        if (channel === "willClose") {
-          let event: StorageEventWillClose = {
-            kind: "willClose",
-            maxLocalIndex: driver.getMaxLocalIndex(),
-          };
-          await this.bus.send(event);
-        } else if (channel === "didClose") {
-          let event: StorageEventDidClose = {
-            kind: "didClose",
-          };
-          loggerSub.debug(
-            "storage did close.  sending that event...",
-          );
-          await this.bus.send(event);
-          loggerSub.debug(
-            "storage did close.  ...and closing the queryFollower...",
-          );
-          await this.close();
-          loggerSub.debug("storage did close.  ...done.");
-        } else if (data === undefined || data.kind === undefined) {
-          loggerSub.error("weird event on channel ", channel);
-          return;
-          // ingest events
-        } else if (event.kind === "success") {
-          // let events through that are after our query's startAfter
-          // and match our query's filter
-          loggerSub.debug(`--- it's a write success.  do we care?`);
-          let doc_li = event.doc._localIndex ?? -1;
-          let query_sa = queryStartAfter;
-          if (doc_li <= query_sa) {
-            loggerSub.debug(
-              `--- don't care; localIndex is old (doc.localIndex ${doc_li} <= queryStartAfter ${query_sa})`,
+        // enforce rules on supported queries
+        logger.debug("...enforcing rules on supported queries");
+        if (query.historyMode !== "all") {
+            throw new NotImplementedError(
+                `QueryFollower historyMode must be 'all'`,
             );
-          } else {
-            if (!docMatchesFilter(event.doc, queryFilter)) {
-              loggerSub.debug(
-                `--- don't care; filter doesn't match`,
-              );
-            } else {
-              loggerSub.debug(
-                `--- we care! filter matches (if there is one) and doc.localIndex comes after query.startAt.`,
-              );
-              loggerSub.debug(
-                `--- running callback blockingly...`,
-              );
-              await this.bus.send(event);
-              loggerSub.debug(`--- ...done running callback`);
-            }
-          }
-          // let all the other kinds of events through
-        } else if (event.kind === "failure") {
-          loggerSub.debug(`--- ingest failure event`);
-          await this.bus.send(event);
-        } else if (event.kind === "nothing_happened") {
-          loggerSub.debug(`--- nothing happened event`);
-          await this.bus.send(event);
-        } else {
-          loggerSub.debug(`--- WARNING: unknown event type event`);
-          console.warn("this should never happen:", event);
-          console.warn(
-            "this should never happen: unrecognised kind of LiveQueryEvent: " +
-              event.kind,
-          );
         }
-      },
-    );
-  }
+        if (query.orderBy !== "localIndex ASC") {
+            throw new NotImplementedError(
+                `QueryFollower orderBy must be 'localIndex ASC'`,
+            );
+        }
+        if (query.limit !== undefined) {
+            throw new NotImplementedError(
+                `QueryFollower must not have a limit`,
+            );
+        }
+    }
 
-  /** Permanently shut down the QueryFollower, unhooking from the storage and stopping the processing of events. */
-  // Triggered when the storage closes
-  // Can also be called manually if you just want to destroy this queryFollower.
-  async close(): Promise<void> {
-    if (this._state === "closed") return;
-    logger.debug("close...");
+    _expectState(states: QueryFollowerState[]) {
+        if (states.indexOf(this._state) === -1) {
+            throw new Error(
+                `QueryFollower expected state to be one of ${
+                    J(states)
+                } but instead found ${this._state}`,
+            );
+        }
+    }
 
-    this._state = "closed";
-    if (this._unsub) this._unsub;
+    /** Returns the follower's state, which can be in two modes:
+     *   1. catching up with the backlog
+     *   2. caught up; processing new events as they happen.
+     * When the query follower is in catching-up mode, it runs independently on its own schedule.  When it's in live mode, it processes each doc  as it's written, blockingly, which means it provides backpressure all the way back up to whatever is trying to ingest() docs into the storage.
+     * There is not currently an easy way to know when a query follower has caught up and switched to live mode, except to listen for the 'idle' event on its bus.
+     */
+    state(): QueryFollowerState {
+        logger.debug("state() => " + this._state);
+        return this._state;
+    }
 
-    let event: QueryFollowerDidClose = { kind: "queryFollowerDidClose" };
-    await this.bus.send(event);
+    /** Begins the process of catching up with existing documents (if needed), then switches to live mode.
+     */
+    async hatch(): Promise<void> {
+        logger.debug("hatch...");
 
-    logger.debug("...close is done.");
+        this._expectState(["new"]);
 
-    return Promise.resolve();
-  }
+        logger.debug("...hatch: calling _catchUp");
+        await this._catchUp();
+        this._expectState(["closed", "error", "live"]);
+        logger.debug("...hatch: done calling _catchUp");
+        logger.debug(`...hatch: state is "${this._state}"`);
+
+        logger.debug(`...hatch is done`);
+    }
+
+    async _catchUp(): Promise<void> {
+        // call this from state "new"
+        // pass through state "catching-up"
+        // end in state:
+        //  "live" is we finished catching up and started the live subscription to the storage
+        //  "closed" if storage became closed
+        //  "error" if something else happened, probably an error from the bus handler
+
+        logger.debug("_catchUp...");
+        this._expectState(["new"]);
+
+        let storage = this.storage;
+        let driver = this.storage.storageDriver;
+        let query = this.query;
+
+        if (query.startAfter === undefined) {
+            logger.debug(
+                `..._catchUp was not needed becaue startAfter is undefined, so we're going right to live mode.`,
+            );
+            this._state = "live";
+            // the moment we become live, we're idle
+            let idleEvent: IdleEvent = { kind: "idle" };
+            await this.bus.send(idleEvent);
+            this._subscribe();
+            return;
+        }
+
+        // catch up if needed
+        this._state = "catching-up";
+        logger.debug(`QueryFollower has a startAfter already; catching up.`);
+        while (true) {
+            let asOf1: number = -100; // before query
+            let asOf2: number = -100; // after query; before callbacks, doesn't really matter
+            let asOf3: number = -100; // after callbacks
+            let maxReturned: number = -100;
+            // do a query
+            try {
+                asOf1 = driver.getMaxLocalIndex();
+                logger.debug(
+                    `...at ${asOf1}, started querying for existing docs`,
+                );
+                // TODO: catch up in smaller batches by setting a limit in the query
+                // TODO: check often to see if the queryfollower itself has been closed
+                let existingDocs = await storage.queryDocs(query);
+                for (let doc of existingDocs) {
+                    maxReturned = Math.max(maxReturned, doc._localIndex ?? -1);
+                }
+                asOf2 = driver.getMaxLocalIndex();
+                logger.debug(
+                    `...at ${asOf2}, got ${existingDocs.length} existing docs`,
+                );
+                logger.debug(`...sending docs to bus...`);
+                for (let doc of existingDocs) {
+                    let event: DocAlreadyExists = {
+                        kind: "existing",
+                        maxLocalIndex: asOf2,
+                        doc: doc, // TODO: should be the just-written doc, frozen, with updated extra properties like _localIndex
+                    };
+                    await this.bus.send(event);
+                }
+                asOf3 = driver.getMaxLocalIndex();
+                logger.debug(
+                    `...at ${asOf3}, finished running ${existingDocs.length} callbacks for existing docs`,
+                );
+            } catch (err) {
+                if (err instanceof StorageIsClosedError) {
+                    logger.debug(
+                        `storage was closed while we were catching up, oh well.`,
+                    );
+                    this.close();
+                } else {
+                    // TODO: what now?  are we stuck in 'error' state?
+                    // should we close?
+                    this._state = "error";
+                    throw err;
+                }
+            }
+
+            // check for stopping conditions for query catch-up loop
+            let asOfSummary =
+                `( asOf: ${asOf1} [query] ${asOf2} [callbacks] ${asOf3}.  maxReturned: ${maxReturned} )`;
+            logger.debug(`...query and callback summary: ${asOfSummary}`);
+            if (asOf1 === asOf3) {
+                logger.debug(
+                    `...asOf stayed at ${asOf1} so nothing new has happened since we did the query, so we can stop catching up now.`,
+                );
+                logger.debug(`...setting startAfter to localIndex: ${asOf1}`);
+                // no changes; we can stop catching up
+                // and let's set startAfter to continue where we just left off.
+                query.startAfter = { localIndex: asOf1 };
+                this._state = "live";
+                // the moment we become live, we're idle
+                let idleEvent: IdleEvent = { kind: "idle" };
+                await this.bus.send(idleEvent);
+                this._subscribe();
+                break;
+            } else {
+                // changes happened.
+                // wait a moment, then do another query to keep catching up.
+                logger.debug(
+                    `...asOf went from ${asOf1} to ${asOf3} so changes happened since we did our query; gotta query again to get those changes.`,
+                );
+                logger.debug(
+                    `...setting startAfter to localIndex: ${maxReturned} which is the max returned doc we saw.`,
+                );
+                query.startAfter = { localIndex: maxReturned };
+                await sleep(10);
+            }
+        } // end of while(true) loop
+
+        logger.debug(
+            `..._catchUp is done, we should now be live: '${this.state()}'`,
+        );
+        this._expectState(["live"]);
+    }
+
+    _subscribe() {
+        // if query did not specify a startAfter, we will start with the next
+        // ingest event that happens.
+
+        // we have just entered live mode, so we need to subscribe to new events.
+        // we'll return an unsubscribe function.
+
+        logger.debug("_subscribe...");
+        this._expectState(["live"]);
+
+        let driver = this.storage.storageDriver;
+        let query = this.query;
+
+        let queryFilter = query.filter || {};
+        let queryStartAfter = driver.getMaxLocalIndex();
+        if (
+            query.startAfter !== undefined &&
+            query.startAfter.localIndex !== undefined
+        ) {
+            queryStartAfter = query.startAfter.localIndex;
+        }
+        logger.debug(`QueryFollower is switching to subscription mode:`);
+        logger.debug(`...queryFilter: ${J(queryFilter)}`);
+        logger.debug(
+            `...start paying attention after local index ${queryStartAfter}.  subscribing...`,
+        );
+
+        this._unsub = this.storage.bus.on(
+            "*",
+            async (channel: StorageBusChannel | "*", data: any) => {
+                this._expectState(["live"]); // make sure the query follower itself has not been closed
+
+                loggerSub.debug(
+                    `--- QueryFollower subscription: got an event on channel ${channel}`,
+                );
+                let event = data as LiveQueryEvent;
+                if (channel === "willClose") {
+                    let event: StorageEventWillClose = {
+                        kind: "willClose",
+                        maxLocalIndex: driver.getMaxLocalIndex(),
+                    };
+                    await this.bus.send(event);
+                } else if (channel === "didClose") {
+                    let event: StorageEventDidClose = {
+                        kind: "didClose",
+                    };
+                    loggerSub.debug(
+                        "storage did close.  sending that event...",
+                    );
+                    await this.bus.send(event);
+                    loggerSub.debug(
+                        "storage did close.  ...and closing the queryFollower...",
+                    );
+                    await this.close();
+                    loggerSub.debug("storage did close.  ...done.");
+                } else if (data === undefined || data.kind === undefined) {
+                    loggerSub.error("weird event on channel ", channel);
+                    return;
+                    // ingest events
+                } else if (event.kind === "success") {
+                    // let events through that are after our query's startAfter
+                    // and match our query's filter
+                    loggerSub.debug(`--- it's a write success.  do we care?`);
+                    let doc_li = event.doc._localIndex ?? -1;
+                    let query_sa = queryStartAfter;
+                    if (doc_li <= query_sa) {
+                        loggerSub.debug(
+                            `--- don't care; localIndex is old (doc.localIndex ${doc_li} <= queryStartAfter ${query_sa})`,
+                        );
+                    } else {
+                        if (!docMatchesFilter(event.doc, queryFilter)) {
+                            loggerSub.debug(
+                                `--- don't care; filter doesn't match`,
+                            );
+                        } else {
+                            loggerSub.debug(
+                                `--- we care! filter matches (if there is one) and doc.localIndex comes after query.startAt.`,
+                            );
+                            loggerSub.debug(
+                                `--- running callback blockingly...`,
+                            );
+                            await this.bus.send(event);
+                            loggerSub.debug(`--- ...done running callback`);
+                        }
+                    }
+                    // let all the other kinds of events through
+                } else if (event.kind === "failure") {
+                    loggerSub.debug(`--- ingest failure event`);
+                    await this.bus.send(event);
+                } else if (event.kind === "nothing_happened") {
+                    loggerSub.debug(`--- nothing happened event`);
+                    await this.bus.send(event);
+                } else {
+                    loggerSub.debug(`--- WARNING: unknown event type event`);
+                    console.warn("this should never happen:", event);
+                    console.warn(
+                        "this should never happen: unrecognised kind of LiveQueryEvent: " +
+                            event.kind,
+                    );
+                }
+            },
+        );
+    }
+
+    /** Permanently shut down the QueryFollower, unhooking from the storage and stopping the processing of events. */
+    // Triggered when the storage closes
+    // Can also be called manually if you just want to destroy this queryFollower.
+    async close(): Promise<void> {
+        if (this._state === "closed") return;
+        logger.debug("close...");
+
+        this._state = "closed";
+        if (this._unsub) this._unsub;
+
+        let event: QueryFollowerDidClose = { kind: "queryFollowerDidClose" };
+        await this.bus.send(event);
+
+        logger.debug("...close is done.");
+
+        return Promise.resolve();
+    }
 }

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -2,31 +2,31 @@ import { Lock, Superbus } from "../../deps.ts";
 
 import { Cmp, Thunk } from "./util-types.ts";
 import {
-  AuthorKeypair,
-  Doc,
-  DocToSet,
-  LocalIndex,
-  Path,
-  WorkspaceAddress,
+    AuthorKeypair,
+    Doc,
+    DocToSet,
+    LocalIndex,
+    Path,
+    WorkspaceAddress,
 } from "../util/doc-types.ts";
 import { HistoryMode, Query } from "../query/query-types.ts";
 import {
-  IngestEvent,
-  IStorageAsync,
-  IStorageDriverAsync,
-  LiveQueryEvent,
-  StorageBusChannel,
-  StorageEventDidClose,
-  StorageEventWillClose,
-  StorageId,
+    IngestEvent,
+    IStorageAsync,
+    IStorageDriverAsync,
+    LiveQueryEvent,
+    StorageBusChannel,
+    StorageEventDidClose,
+    StorageEventWillClose,
+    StorageId,
 } from "./storage-types.ts";
 import { IFormatValidator } from "../format-validators/format-validator-types.ts";
 
 import {
-  isErr,
-  NotImplementedError,
-  StorageIsClosedError,
-  ValidationError,
+    isErr,
+    NotImplementedError,
+    StorageIsClosedError,
+    ValidationError,
 } from "../util/errors.ts";
 import { microsecondNow, randomId, sleep } from "../util/misc.ts";
 import { compareArrays } from "./compare.ts";
@@ -36,20 +36,15 @@ import { docMatchesFilter } from "../query/query.ts";
 
 //--------------------------------------------------
 
-import {
-  Logger,
-  LogLevel,
-  setDefaultLogLevel,
-  setLogLevel,
-} from "../util/log.ts";
+import { Logger, LogLevel, setDefaultLogLevel, setLogLevel } from "../util/log.ts";
 let J = JSON.stringify;
 let logger = new Logger("storage async", "yellowBright");
 let loggerSet = new Logger("storage async set", "yellowBright");
 let loggerIngest = new Logger("storage async ingest", "yellowBright");
 let loggerLiveQuery = new Logger("storage live query", "magentaBright");
 let loggerLiveQuerySubscription = new Logger(
-  "storage live query subscription",
-  "magenta",
+    "storage live query subscription",
+    "magenta",
 );
 
 //setDefaultLogLevel(LogLevel.None);
@@ -62,12 +57,12 @@ let loggerLiveQuerySubscription = new Logger(
 //================================================================================
 
 function docCompareNewestFirst(a: Doc, b: Doc): Cmp {
-  // Sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
-  return compareArrays(
-    [a.timestamp, a.signature],
-    [b.timestamp, a.signature],
-    ["DESC", "ASC"],
-  );
+    // Sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
+    return compareArrays(
+        [a.timestamp, a.signature],
+        [b.timestamp, a.signature],
+        ["DESC", "ASC"],
+    );
 }
 
 /**
@@ -78,154 +73,154 @@ function docCompareNewestFirst(a: Doc, b: Doc): Cmp {
  * ```
  */
 export class StorageAsync implements IStorageAsync {
-  storageId: StorageId; // todo: save it to the driver too, and reload it when starting up
-  /** The address of the share this replica belongs to. */
-  workspace: WorkspaceAddress;
-  /** The validator used to validate ingested documents. */
-  formatValidator: IFormatValidator;
-  storageDriver: IStorageDriverAsync;
-  bus: Superbus<StorageBusChannel>;
+    storageId: StorageId; // todo: save it to the driver too, and reload it when starting up
+    /** The address of the share this replica belongs to. */
+    workspace: WorkspaceAddress;
+    /** The validator used to validate ingested documents. */
+    formatValidator: IFormatValidator;
+    storageDriver: IStorageDriverAsync;
+    bus: Superbus<StorageBusChannel>;
 
-  _isClosed: boolean = false;
-  _ingestLock: Lock<IngestEvent>;
+    _isClosed: boolean = false;
+    _ingestLock: Lock<IngestEvent>;
 
-  constructor(
-    workspace: WorkspaceAddress,
-    validator: IFormatValidator,
-    driver: IStorageDriverAsync,
-  ) {
-    logger.debug(
-      `constructor.  driver = ${(driver as any)?.constructor?.name}`,
-    );
-    this.storageId = "storage-" + randomId();
-    this.workspace = workspace;
-    this.formatValidator = validator;
-    this.storageDriver = driver;
-    this.bus = new Superbus<StorageBusChannel>("|");
-    this._ingestLock = new Lock<IngestEvent>();
-  }
+    constructor(
+        workspace: WorkspaceAddress,
+        validator: IFormatValidator,
+        driver: IStorageDriverAsync,
+    ) {
+        logger.debug(
+            `constructor.  driver = ${(driver as any)?.constructor?.name}`,
+        );
+        this.storageId = "storage-" + randomId();
+        this.workspace = workspace;
+        this.formatValidator = validator;
+        this.storageDriver = driver;
+        this.bus = new Superbus<StorageBusChannel>("|");
+        this._ingestLock = new Lock<IngestEvent>();
+    }
 
-  //--------------------------------------------------
-  // LIFECYCLE
+    //--------------------------------------------------
+    // LIFECYCLE
 
-  /** Returns whether the storage is closed or not. */
-  isClosed(): boolean {
-    return this._isClosed;
-  }
+    /** Returns whether the storage is closed or not. */
+    isClosed(): boolean {
+        return this._isClosed;
+    }
 
-  /**
-   * Closes the replica, preventing new documents from being ingested or events being emitted.
-   * Any methods called after closing will return `StorageIsClosedError`.
-   * @param erase - Erase the contents of the replica. Defaults to `false`.
-   */
-  async close(erase: boolean): Promise<void> {
-    logger.debug("closing...");
-    if (this._isClosed) throw new StorageIsClosedError();
-    // TODO: do this all in a lock?
-    logger.debug("    sending willClose blockingly...");
-    await this.bus.sendAndWait("willClose");
-    logger.debug("    marking self as closed...");
-    this._isClosed = true;
-    logger.debug(`    closing storageDriver (erase = ${erase})...`);
-    await this.storageDriver.close(erase);
-    logger.debug("    sending didClose nonblockingly...");
-    this.bus.sendLater("didClose");
-    logger.debug("...closing done");
+    /**
+     * Closes the replica, preventing new documents from being ingested or events being emitted.
+     * Any methods called after closing will return `StorageIsClosedError`.
+     * @param erase - Erase the contents of the replica. Defaults to `false`.
+     */
+    async close(erase: boolean): Promise<void> {
+        logger.debug("closing...");
+        if (this._isClosed) throw new StorageIsClosedError();
+        // TODO: do this all in a lock?
+        logger.debug("    sending willClose blockingly...");
+        await this.bus.sendAndWait("willClose");
+        logger.debug("    marking self as closed...");
+        this._isClosed = true;
+        logger.debug(`    closing storageDriver (erase = ${erase})...`);
+        await this.storageDriver.close(erase);
+        logger.debug("    sending didClose nonblockingly...");
+        this.bus.sendLater("didClose");
+        logger.debug("...closing done");
 
-    return Promise.resolve();
-  }
+        return Promise.resolve();
+    }
 
-  //--------------------------------------------------
-  // CONFIG
+    //--------------------------------------------------
+    // CONFIG
 
-  async getConfig(key: string): Promise<string | undefined> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.getConfig(key);
-  }
-  async setConfig(key: string, value: string): Promise<void> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.setConfig(key, value);
-  }
-  async listConfigKeys(): Promise<string[]> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.listConfigKeys();
-  }
-  async deleteConfig(key: string): Promise<boolean> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.deleteConfig(key);
-  }
+    async getConfig(key: string): Promise<string | undefined> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.getConfig(key);
+    }
+    async setConfig(key: string, value: string): Promise<void> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.setConfig(key, value);
+    }
+    async listConfigKeys(): Promise<string[]> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.listConfigKeys();
+    }
+    async deleteConfig(key: string): Promise<boolean> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.deleteConfig(key);
+    }
 
-  //--------------------------------------------------
-  // GET
+    //--------------------------------------------------
+    // GET
 
-  /** Returns the max local index of all stored documents */
-  getMaxLocalIndex(): number {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return this.storageDriver.getMaxLocalIndex();
-  }
+    /** Returns the max local index of all stored documents */
+    getMaxLocalIndex(): number {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return this.storageDriver.getMaxLocalIndex();
+    }
 
-  async getDocsAfterLocalIndex(
-    historyMode: HistoryMode,
-    startAfter: LocalIndex,
-    limit?: number,
-  ): Promise<Doc[]> {
-    logger.debug(
-      `getDocsAfterLocalIndex(${historyMode}, ${startAfter}, ${limit})`,
-    );
-    if (this._isClosed) throw new StorageIsClosedError();
-    let query: Query = {
-      historyMode: historyMode,
-      orderBy: "localIndex ASC",
-      startAfter: {
-        localIndex: startAfter,
-      },
-      limit,
-    };
-    return await this.storageDriver.queryDocs(query);
-  }
+    async getDocsAfterLocalIndex(
+        historyMode: HistoryMode,
+        startAfter: LocalIndex,
+        limit?: number,
+    ): Promise<Doc[]> {
+        logger.debug(
+            `getDocsAfterLocalIndex(${historyMode}, ${startAfter}, ${limit})`,
+        );
+        if (this._isClosed) throw new StorageIsClosedError();
+        let query: Query = {
+            historyMode: historyMode,
+            orderBy: "localIndex ASC",
+            startAfter: {
+                localIndex: startAfter,
+            },
+            limit,
+        };
+        return await this.storageDriver.queryDocs(query);
+    }
 
-  /** Returns all documents, including historical versions of documents by other identities. */
-  async getAllDocs(): Promise<Doc[]> {
-    logger.debug(`getAllDocs()`);
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.queryDocs({
-      historyMode: "all",
-      orderBy: "path ASC",
-    });
-  }
-  /** Returns latest document from every path. */
-  async getLatestDocs(): Promise<Doc[]> {
-    logger.debug(`getLatestDocs()`);
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.queryDocs({
-      historyMode: "latest",
-      orderBy: "path ASC",
-    });
-  }
-  /** Returns all versions of a document by different authors from a specific path. */
-  async getAllDocsAtPath(path: Path): Promise<Doc[]> {
-    logger.debug(`getAllDocsAtPath("${path}")`);
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.queryDocs({
-      historyMode: "all",
-      orderBy: "path ASC",
-      filter: { path: path },
-    });
-  }
-  /** Returns the most recently written version of a document at a path. */
-  async getLatestDocAtPath(path: Path): Promise<Doc | undefined> {
-    logger.debug(`getLatestDocsAtPath("${path}")`);
-    if (this._isClosed) throw new StorageIsClosedError();
-    let docs = await this.storageDriver.queryDocs({
-      historyMode: "latest",
-      orderBy: "path ASC",
-      filter: { path: path },
-    });
-    if (docs.length === 0) return undefined;
-    return docs[0];
-  }
+    /** Returns all documents, including historical versions of documents by other identities. */
+    async getAllDocs(): Promise<Doc[]> {
+        logger.debug(`getAllDocs()`);
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.queryDocs({
+            historyMode: "all",
+            orderBy: "path ASC",
+        });
+    }
+    /** Returns latest document from every path. */
+    async getLatestDocs(): Promise<Doc[]> {
+        logger.debug(`getLatestDocs()`);
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.queryDocs({
+            historyMode: "latest",
+            orderBy: "path ASC",
+        });
+    }
+    /** Returns all versions of a document by different authors from a specific path. */
+    async getAllDocsAtPath(path: Path): Promise<Doc[]> {
+        logger.debug(`getAllDocsAtPath("${path}")`);
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.queryDocs({
+            historyMode: "all",
+            orderBy: "path ASC",
+            filter: { path: path },
+        });
+    }
+    /** Returns the most recently written version of a document at a path. */
+    async getLatestDocAtPath(path: Path): Promise<Doc | undefined> {
+        logger.debug(`getLatestDocsAtPath("${path}")`);
+        if (this._isClosed) throw new StorageIsClosedError();
+        let docs = await this.storageDriver.queryDocs({
+            historyMode: "latest",
+            orderBy: "path ASC",
+            filter: { path: path },
+        });
+        if (docs.length === 0) return undefined;
+        return docs[0];
+    }
 
-  /** Returns an array of docs for a given query.
+    /** Returns an array of docs for a given query.
     ```
     const myQuery = {
       filter: {
@@ -237,294 +232,292 @@ export class StorageAsync implements IStorageAsync {
     const firstFiveTextDocs = await myReplica.queryDocs(myQuery);
     ```
     */
-  async queryDocs(query: Query = {}): Promise<Doc[]> {
-    logger.debug(`queryDocs`, query);
-    if (this._isClosed) throw new StorageIsClosedError();
-    return await this.storageDriver.queryDocs(query);
-  }
+    async queryDocs(query: Query = {}): Promise<Doc[]> {
+        logger.debug(`queryDocs`, query);
+        if (this._isClosed) throw new StorageIsClosedError();
+        return await this.storageDriver.queryDocs(query);
+    }
 
-  //queryPaths(query?: Query): Path[];
-  //queryAuthors(query?: Query): AuthorAddress[];
+    //queryPaths(query?: Query): Path[];
+    //queryAuthors(query?: Query): AuthorAddress[];
 
-  //--------------------------------------------------
-  // SET
+    //--------------------------------------------------
+    // SET
 
-  /**
-   * Adds a new document to the replica. If a document signed by the same identity exists at the same path, it will be overwritten.
-   */
-  async set(
-    keypair: AuthorKeypair,
-    docToSet: DocToSet,
-  ): Promise<IngestEvent> {
-    loggerSet.debug(`set`, docToSet);
-    if (this._isClosed) throw new StorageIsClosedError();
+    /**
+     * Adds a new document to the replica. If a document signed by the same identity exists at the same path, it will be overwritten.
+     */
+    async set(
+        keypair: AuthorKeypair,
+        docToSet: DocToSet,
+    ): Promise<IngestEvent> {
+        loggerSet.debug(`set`, docToSet);
+        if (this._isClosed) throw new StorageIsClosedError();
 
-    loggerSet.debug(
-      "...deciding timestamp: getting latest doc at the same path (from any author)",
-    );
-
-    let timestamp: number;
-    if (typeof docToSet.timestamp === "number") {
-      timestamp = docToSet.timestamp;
-      loggerSet.debug(
-        "...docToSet already has a timestamp; not changing it from ",
-        timestamp,
-      );
-    } else {
-      // bump timestamp if needed to win over existing latest doc at same path
-      let latestDocSamePath = await this.getLatestDocAtPath(
-        docToSet.path,
-      );
-      if (latestDocSamePath === undefined) {
-        timestamp = microsecondNow();
         loggerSet.debug(
-          "...no existing latest doc, setting timestamp to now() =",
-          timestamp,
+            "...deciding timestamp: getting latest doc at the same path (from any author)",
         );
-      } else {
-        timestamp = Math.max(
-          microsecondNow(),
-          latestDocSamePath.timestamp + 1,
-        );
-        loggerSet.debug(
-          "...existing latest doc found, bumping timestamp to win if needed =",
-          timestamp,
-        );
-      }
-    }
 
-    let doc: Doc = {
-      format: "es.4",
-      author: keypair.address,
-      content: docToSet.content,
-      contentHash: await Crypto.sha256base32(docToSet.content),
-      deleteAfter: docToSet.deleteAfter ?? null,
-      path: docToSet.path,
-      timestamp,
-      workspace: this.workspace,
-      signature: "?", // signature will be added in just a moment
-      // _localIndex will be added during upsert.  it's not needed for the signature.
-    };
-
-    loggerSet.debug("...signing doc");
-    let signedDoc = await this.formatValidator.signDocument(keypair, doc);
-    if (isErr(signedDoc)) {
-      return {
-        kind: "failure",
-        reason: "invalid_document",
-        err: signedDoc,
-        maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
-      };
-    }
-    loggerSet.debug("...signature =", signedDoc.signature);
-
-    loggerSet.debug("...ingesting");
-    loggerSet.debug("-----------------------");
-    let ingestEvent = await this.ingest(signedDoc);
-    loggerSet.debug("-----------------------");
-    loggerSet.debug("...done ingesting");
-    loggerSet.debug("...set is done.");
-    return ingestEvent;
-  }
-
-  /**
-   * Ingest an existing signed document to the replica.
-   */
-  async ingest(docToIngest: Doc): Promise<IngestEvent> {
-    loggerIngest.debug(`ingest`, docToIngest);
-    if (this._isClosed) throw new StorageIsClosedError();
-
-    loggerIngest.debug("...removing extra fields");
-    let removeResultsOrErr = this.formatValidator.removeExtraFields(
-      docToIngest,
-    );
-    if (isErr(removeResultsOrErr)) {
-      return {
-        kind: "failure",
-        reason: "invalid_document",
-        err: removeResultsOrErr,
-        maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
-      };
-    }
-    docToIngest = removeResultsOrErr.doc; // a copy of doc without extra fields
-    let extraFields = removeResultsOrErr.extras; // any extra fields starting with underscores
-    if (Object.keys(extraFields).length > 0) {
-      loggerIngest.debug(`...extra fields found: ${J(extraFields)}`);
-    }
-
-    // now actually check doc validity against core schema
-    let docIsValid = this.formatValidator.checkDocumentIsValid(docToIngest);
-    if (isErr(docIsValid)) {
-      return {
-        kind: "failure",
-        reason: "invalid_document",
-        err: docIsValid,
-        maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
-      };
-    }
-
-    let writeToDriverWithLock = async (): Promise<IngestEvent> => {
-      // get other docs at the same path
-      loggerIngest.debug(" >> ingest: start of protected region");
-      loggerIngest.debug(
-        "  > getting other history docs at the same path by any author",
-      );
-      let existingDocsSamePath = await this.getAllDocsAtPath(
-        docToIngest.path,
-      );
-      loggerIngest.debug(`  > ...got ${existingDocsSamePath.length}`);
-
-      loggerIngest.debug("  > getting prevLatest and prevSameAuthor");
-      let prevLatest: Doc | null = existingDocsSamePath[0] ?? null;
-      let prevSameAuthor: Doc | null =
-        existingDocsSamePath.filter((d) =>
-          d.author === docToIngest.author
-        )[0] ??
-          null;
-
-      loggerIngest.debug(
-        "  > checking if new doc is latest at this path",
-      );
-      existingDocsSamePath.push(docToIngest);
-      existingDocsSamePath.sort(docCompareNewestFirst);
-      let isLatest = existingDocsSamePath[0] === docToIngest;
-      loggerIngest.debug(`  > ...isLatest: ${isLatest}`);
-
-      if (!isLatest && prevSameAuthor !== null) {
-        loggerIngest.debug(
-          "  > new doc is not latest and there is another one from the same author...",
-        );
-        // check if this is obsolete or redudant from the same author
-        let docComp = docCompareNewestFirst(
-          docToIngest,
-          prevSameAuthor,
-        );
-        if (docComp === Cmp.GT) {
-          loggerIngest.debug(
-            "  > new doc is GT prevSameAuthor, so it is obsolete",
-          );
-          return {
-            kind: "nothing_happened",
-            reason: "obsolete_from_same_author",
-            doc: docToIngest,
-            maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
-          };
+        let timestamp: number;
+        if (typeof docToSet.timestamp === "number") {
+            timestamp = docToSet.timestamp;
+            loggerSet.debug(
+                "...docToSet already has a timestamp; not changing it from ",
+                timestamp,
+            );
+        } else {
+            // bump timestamp if needed to win over existing latest doc at same path
+            let latestDocSamePath = await this.getLatestDocAtPath(
+                docToSet.path,
+            );
+            if (latestDocSamePath === undefined) {
+                timestamp = microsecondNow();
+                loggerSet.debug(
+                    "...no existing latest doc, setting timestamp to now() =",
+                    timestamp,
+                );
+            } else {
+                timestamp = Math.max(
+                    microsecondNow(),
+                    latestDocSamePath.timestamp + 1,
+                );
+                loggerSet.debug(
+                    "...existing latest doc found, bumping timestamp to win if needed =",
+                    timestamp,
+                );
+            }
         }
-        if (docComp === Cmp.EQ) {
-          loggerIngest.debug(
-            "  > new doc is EQ prevSameAuthor, so it is redundant (already_had_it)",
-          );
-          return {
-            kind: "nothing_happened",
-            reason: "already_had_it",
-            doc: docToIngest,
-            maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
-          };
+
+        let doc: Doc = {
+            format: "es.4",
+            author: keypair.address,
+            content: docToSet.content,
+            contentHash: await Crypto.sha256base32(docToSet.content),
+            deleteAfter: docToSet.deleteAfter ?? null,
+            path: docToSet.path,
+            timestamp,
+            workspace: this.workspace,
+            signature: "?", // signature will be added in just a moment
+            // _localIndex will be added during upsert.  it's not needed for the signature.
+        };
+
+        loggerSet.debug("...signing doc");
+        let signedDoc = await this.formatValidator.signDocument(keypair, doc);
+        if (isErr(signedDoc)) {
+            return {
+                kind: "failure",
+                reason: "invalid_document",
+                err: signedDoc,
+                maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
+            };
         }
-      }
+        loggerSet.debug("...signature =", signedDoc.signature);
 
-      // save it
-      loggerIngest.debug("  > upserting into storageDriver...");
-      let docAsWritten = await this.storageDriver.upsert(docToIngest); // TODO: pass existingDocsSamePath to save another lookup
-      loggerIngest.debug("  > ...done upserting into storageDriver");
-      loggerIngest.debug("  > ...getting storageDriver maxLocalIndex...");
-      let maxLocalIndex = this.storageDriver.getMaxLocalIndex();
+        loggerSet.debug("...ingesting");
+        loggerSet.debug("-----------------------");
+        let ingestEvent = await this.ingest(signedDoc);
+        loggerSet.debug("-----------------------");
+        loggerSet.debug("...done ingesting");
+        loggerSet.debug("...set is done.");
+        return ingestEvent;
+    }
 
-      loggerIngest.debug(
-        " >> ingest: end of protected region, returning a WriteEvent from the lock",
-      );
-      return {
-        kind: "success",
-        maxLocalIndex,
-        doc: docAsWritten, // with updated extra properties like _localIndex
-        docIsLatest: isLatest,
-        prevDocFromSameAuthor: prevSameAuthor,
-        prevLatestDoc: prevLatest,
-      };
-    };
+    /**
+     * Ingest an existing signed document to the replica.
+     */
+    async ingest(docToIngest: Doc): Promise<IngestEvent> {
+        loggerIngest.debug(`ingest`, docToIngest);
+        if (this._isClosed) throw new StorageIsClosedError();
 
-    loggerIngest.debug(" >> ingest: running protected region...");
-    let ingestEvent: IngestEvent = await this._ingestLock.run(
-      writeToDriverWithLock,
-    );
-    loggerIngest.debug(" >> ingest: ...done running protected region");
+        loggerIngest.debug("...removing extra fields");
+        let removeResultsOrErr = this.formatValidator.removeExtraFields(
+            docToIngest,
+        );
+        if (isErr(removeResultsOrErr)) {
+            return {
+                kind: "failure",
+                reason: "invalid_document",
+                err: removeResultsOrErr,
+                maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
+            };
+        }
+        docToIngest = removeResultsOrErr.doc; // a copy of doc without extra fields
+        let extraFields = removeResultsOrErr.extras; // any extra fields starting with underscores
+        if (Object.keys(extraFields).length > 0) {
+            loggerIngest.debug(`...extra fields found: ${J(extraFields)}`);
+        }
 
-    loggerIngest.debug("...send ingest event after releasing the lock");
-    loggerIngest.debug("...ingest event:", ingestEvent);
-    await this.bus.sendAndWait(
-      `ingest|${docToIngest.path}` as unknown as "ingest",
-      ingestEvent,
-    ); // include the path in the channel even on failures
+        // now actually check doc validity against core schema
+        let docIsValid = this.formatValidator.checkDocumentIsValid(docToIngest);
+        if (isErr(docIsValid)) {
+            return {
+                kind: "failure",
+                reason: "invalid_document",
+                err: docIsValid,
+                maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
+            };
+        }
 
-    return ingestEvent;
-  }
+        let writeToDriverWithLock = async (): Promise<IngestEvent> => {
+            // get other docs at the same path
+            loggerIngest.debug(" >> ingest: start of protected region");
+            loggerIngest.debug(
+                "  > getting other history docs at the same path by any author",
+            );
+            let existingDocsSamePath = await this.getAllDocsAtPath(
+                docToIngest.path,
+            );
+            loggerIngest.debug(`  > ...got ${existingDocsSamePath.length}`);
 
-  /**
+            loggerIngest.debug("  > getting prevLatest and prevSameAuthor");
+            let prevLatest: Doc | null = existingDocsSamePath[0] ?? null;
+            let prevSameAuthor: Doc | null =
+                existingDocsSamePath.filter((d) => d.author === docToIngest.author)[0] ??
+                    null;
+
+            loggerIngest.debug(
+                "  > checking if new doc is latest at this path",
+            );
+            existingDocsSamePath.push(docToIngest);
+            existingDocsSamePath.sort(docCompareNewestFirst);
+            let isLatest = existingDocsSamePath[0] === docToIngest;
+            loggerIngest.debug(`  > ...isLatest: ${isLatest}`);
+
+            if (!isLatest && prevSameAuthor !== null) {
+                loggerIngest.debug(
+                    "  > new doc is not latest and there is another one from the same author...",
+                );
+                // check if this is obsolete or redudant from the same author
+                let docComp = docCompareNewestFirst(
+                    docToIngest,
+                    prevSameAuthor,
+                );
+                if (docComp === Cmp.GT) {
+                    loggerIngest.debug(
+                        "  > new doc is GT prevSameAuthor, so it is obsolete",
+                    );
+                    return {
+                        kind: "nothing_happened",
+                        reason: "obsolete_from_same_author",
+                        doc: docToIngest,
+                        maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
+                    };
+                }
+                if (docComp === Cmp.EQ) {
+                    loggerIngest.debug(
+                        "  > new doc is EQ prevSameAuthor, so it is redundant (already_had_it)",
+                    );
+                    return {
+                        kind: "nothing_happened",
+                        reason: "already_had_it",
+                        doc: docToIngest,
+                        maxLocalIndex: this.storageDriver.getMaxLocalIndex(),
+                    };
+                }
+            }
+
+            // save it
+            loggerIngest.debug("  > upserting into storageDriver...");
+            let docAsWritten = await this.storageDriver.upsert(docToIngest); // TODO: pass existingDocsSamePath to save another lookup
+            loggerIngest.debug("  > ...done upserting into storageDriver");
+            loggerIngest.debug("  > ...getting storageDriver maxLocalIndex...");
+            let maxLocalIndex = this.storageDriver.getMaxLocalIndex();
+
+            loggerIngest.debug(
+                " >> ingest: end of protected region, returning a WriteEvent from the lock",
+            );
+            return {
+                kind: "success",
+                maxLocalIndex,
+                doc: docAsWritten, // with updated extra properties like _localIndex
+                docIsLatest: isLatest,
+                prevDocFromSameAuthor: prevSameAuthor,
+                prevLatestDoc: prevLatest,
+            };
+        };
+
+        loggerIngest.debug(" >> ingest: running protected region...");
+        let ingestEvent: IngestEvent = await this._ingestLock.run(
+            writeToDriverWithLock,
+        );
+        loggerIngest.debug(" >> ingest: ...done running protected region");
+
+        loggerIngest.debug("...send ingest event after releasing the lock");
+        loggerIngest.debug("...ingest event:", ingestEvent);
+        await this.bus.sendAndWait(
+            `ingest|${docToIngest.path}` as unknown as "ingest",
+            ingestEvent,
+        ); // include the path in the channel even on failures
+
+        return ingestEvent;
+    }
+
+    /**
    * Overwrite every document from this author, including history versions, with an empty doc.
     @returns The number of documents changed, or -1 if there was an error.
    */
-  async overwriteAllDocsByAuthor(
-    keypair: AuthorKeypair,
-  ): Promise<number | ValidationError> {
-    logger.debug(`overwriteAllDocsByAuthor("${keypair.address}")`);
-    if (this._isClosed) throw new StorageIsClosedError();
-    // TODO: do this in batches
-    let docsToOverwrite = await this.queryDocs({
-      filter: { author: keypair.address },
-      historyMode: "all",
-    });
-    logger.debug(
-      `    ...found ${docsToOverwrite.length} docs to overwrite`,
-    );
-    let numOverwritten = 0;
-    let numAlreadyEmpty = 0;
-    for (let doc of docsToOverwrite) {
-      if (doc.content.length === 0) {
-        numAlreadyEmpty += 1;
-        continue;
-      }
-
-      // remove extra fields
-      let cleanedResult = this.formatValidator.removeExtraFields(doc);
-      if (isErr(cleanedResult)) return cleanedResult;
-      let cleanedDoc = cleanedResult.doc;
-
-      // make new doc which is empty and just barely newer than the original
-      let emptyDoc: Doc = {
-        ...cleanedDoc,
-        content: "",
-        contentHash: await Crypto.sha256base32(""),
-        timestamp: doc.timestamp + 1,
-        signature: "?",
-      };
-
-      // sign and ingest it
-      let signedDoc = await this.formatValidator.signDocument(
-        keypair,
-        emptyDoc,
-      );
-      if (isErr(signedDoc)) return signedDoc;
-
-      let ingestEvent = await this.ingest(signedDoc);
-      if (ingestEvent.kind === "failure") {
-        return new ValidationError(
-          "ingestion error during overwriteAllDocsBySameAuthor: " +
-            ingestEvent.reason + ": " + ingestEvent.err,
+    async overwriteAllDocsByAuthor(
+        keypair: AuthorKeypair,
+    ): Promise<number | ValidationError> {
+        logger.debug(`overwriteAllDocsByAuthor("${keypair.address}")`);
+        if (this._isClosed) throw new StorageIsClosedError();
+        // TODO: do this in batches
+        let docsToOverwrite = await this.queryDocs({
+            filter: { author: keypair.address },
+            historyMode: "all",
+        });
+        logger.debug(
+            `    ...found ${docsToOverwrite.length} docs to overwrite`,
         );
-      }
-      if (ingestEvent.kind === "nothing_happened") {
-        return new ValidationError(
-          "ingestion did nothing during overwriteAllDocsBySameAuthor: " +
-            ingestEvent.reason,
+        let numOverwritten = 0;
+        let numAlreadyEmpty = 0;
+        for (let doc of docsToOverwrite) {
+            if (doc.content.length === 0) {
+                numAlreadyEmpty += 1;
+                continue;
+            }
+
+            // remove extra fields
+            let cleanedResult = this.formatValidator.removeExtraFields(doc);
+            if (isErr(cleanedResult)) return cleanedResult;
+            let cleanedDoc = cleanedResult.doc;
+
+            // make new doc which is empty and just barely newer than the original
+            let emptyDoc: Doc = {
+                ...cleanedDoc,
+                content: "",
+                contentHash: await Crypto.sha256base32(""),
+                timestamp: doc.timestamp + 1,
+                signature: "?",
+            };
+
+            // sign and ingest it
+            let signedDoc = await this.formatValidator.signDocument(
+                keypair,
+                emptyDoc,
+            );
+            if (isErr(signedDoc)) return signedDoc;
+
+            let ingestEvent = await this.ingest(signedDoc);
+            if (ingestEvent.kind === "failure") {
+                return new ValidationError(
+                    "ingestion error during overwriteAllDocsBySameAuthor: " +
+                        ingestEvent.reason + ": " + ingestEvent.err,
+                );
+            }
+            if (ingestEvent.kind === "nothing_happened") {
+                return new ValidationError(
+                    "ingestion did nothing during overwriteAllDocsBySameAuthor: " +
+                        ingestEvent.reason,
+                );
+            } else {
+                // success
+                numOverwritten += 1;
+            }
+        }
+        logger.debug(
+            `    ...done; ${numOverwritten} overwritten to be empty; ${numAlreadyEmpty} were already empty; out of total ${docsToOverwrite.length} docs`,
         );
-      } else {
-        // success
-        numOverwritten += 1;
-      }
+        return numOverwritten;
     }
-    logger.debug(
-      `    ...done; ${numOverwritten} overwritten to be empty; ${numAlreadyEmpty} were already empty; out of total ${docsToOverwrite.length} docs`,
-    );
-    return numOverwritten;
-  }
 }

--- a/src/storage/storage-driver-async-memory.ts
+++ b/src/storage/storage-driver-async-memory.ts
@@ -15,261 +15,261 @@ let logger = new Logger("storage driver async memory", "yellow");
 //================================================================================
 
 function combinePathAndAuthor(doc: Doc) {
-  // This is used as a key into the path&author index
-  // It must use a separator character that's not valid in either paths or author addresses
-  return `${doc.path}|${doc.author}`;
+    // This is used as a key into the path&author index
+    // It must use a separator character that's not valid in either paths or author addresses
+    return `${doc.path}|${doc.author}`;
 }
 
 function docComparePathASCthenNewestFirst(a: Doc, b: Doc): Cmp {
-  // Sorts docs by path ASC.
-  // Within each paths, sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
-  return compareArrays(
-    [a.path, a.timestamp, a.signature],
-    [b.path, b.timestamp, a.signature],
-    ["ASC", "DESC", "ASC"],
-  );
+    // Sorts docs by path ASC.
+    // Within each paths, sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
+    return compareArrays(
+        [a.path, a.timestamp, a.signature],
+        [b.path, b.timestamp, a.signature],
+        ["ASC", "DESC", "ASC"],
+    );
 }
 
 function docComparePathDESCthenNewestFirst(a: Doc, b: Doc): Cmp {
-  // Sorts docs by path DESC.
-  // Within each paths, sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
-  return compareArrays(
-    [a.path, a.timestamp, a.signature],
-    [b.path, b.timestamp, a.signature],
-    ["DESC", "DESC", "ASC"],
-  );
+    // Sorts docs by path DESC.
+    // Within each paths, sorts by timestamp DESC (newest fist) and breaks ties using the signature ASC.
+    return compareArrays(
+        [a.path, a.timestamp, a.signature],
+        [b.path, b.timestamp, a.signature],
+        ["DESC", "DESC", "ASC"],
+    );
 }
 
 /** An in-memory storage driver. Its contents will be lost when it is closed.
  * Works everywhere.
  */
 export class StorageDriverAsyncMemory implements IStorageDriverAsync {
-  workspace: WorkspaceAddress;
-  _maxLocalIndex: LocalIndex = -1; // when empty, the max is -1.  when one item is present, starting with index 0, the max is 0
-  _isClosed: boolean = false;
-  _configKv: Record<string, string> = {};
+    workspace: WorkspaceAddress;
+    _maxLocalIndex: LocalIndex = -1; // when empty, the max is -1.  when one item is present, starting with index 0, the max is 0
+    _isClosed: boolean = false;
+    _configKv: Record<string, string> = {};
 
-  // Our indexes.
-  // These maps all share the same Doc objects, so memory usage is not bad.
-  // The Doc objects are frozen.
-  docByPathAndAuthor: Map<string, Doc> = new Map(); // path+author --> doc
-  docsByPathNewestFirst: Map<Path, Doc[]> = new Map(); // path --> array of docs with that path, sorted newest first
+    // Our indexes.
+    // These maps all share the same Doc objects, so memory usage is not bad.
+    // The Doc objects are frozen.
+    docByPathAndAuthor: Map<string, Doc> = new Map(); // path+author --> doc
+    docsByPathNewestFirst: Map<Path, Doc[]> = new Map(); // path --> array of docs with that path, sorted newest first
 
-  /**
-   * @param workspace - The address of the share the replica belongs to.
-   */
-  constructor(workspace: WorkspaceAddress) {
-    logger.debug("constructor");
-    this.workspace = workspace;
-  }
-
-  //--------------------------------------------------
-  // LIFECYCLE
-
-  isClosed(): boolean {
-    return this._isClosed;
-  }
-  close(erase: boolean) {
-    logger.debug("close");
-    if (this._isClosed) throw new StorageIsClosedError();
-    if (erase) {
-      logger.debug("...close: and erase");
-      // this is an in-memory store so we don't really need to delete anything,
-      // but this might help free up memory for the garbage collector
-      this._configKv = {};
-      this._maxLocalIndex = -1;
-      this.docsByPathNewestFirst.clear();
-      this.docByPathAndAuthor.clear();
-    }
-    this._isClosed = true;
-    logger.debug("...close is done.");
-
-    return Promise.resolve();
-  }
-
-  //--------------------------------------------------
-  // CONFIG
-
-  async getConfig(key: string): Promise<string | undefined> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return this._configKv[key];
-  }
-  async setConfig(key: string, value: string): Promise<void> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    this._configKv[key] = value;
-  }
-  async listConfigKeys(): Promise<string[]> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    return sortedInPlace(Object.keys(this._configKv));
-  }
-  async deleteConfig(key: string): Promise<boolean> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    let had = (key in this._configKv);
-    delete this._configKv[key];
-    return had;
-  }
-
-  //--------------------------------------------------
-  // GET
-
-  getMaxLocalIndex() {
-    if (this._isClosed) throw new StorageIsClosedError();
-    logger.debug(`getMaxLocalIndex(): it's ${this._maxLocalIndex}`);
-    return this._maxLocalIndex;
-  }
-
-  async _getAllDocs(): Promise<Doc[]> {
-    // return in unsorted order
-    if (this._isClosed) throw new StorageIsClosedError();
-    return [...this.docByPathAndAuthor.values()];
-  }
-  async _getLatestDocs(): Promise<Doc[]> {
-    // return in unsorted order
-    if (this._isClosed) throw new StorageIsClosedError();
-    let docs: Doc[] = [];
-    for (let docArray of this.docsByPathNewestFirst.values()) {
-      // this array is kept sorted newest-first
-      docs.push(docArray[0]);
-    }
-    return docs;
-  }
-
-  async queryDocs(queryToClean: Query): Promise<Doc[]> {
-    // Query the documents.
-
-    logger.debug("queryDocs", queryToClean);
-    if (this._isClosed) throw new StorageIsClosedError();
-
-    // clean up the query and exit early if possible.
-    let { query, willMatch } = cleanUpQuery(queryToClean);
-    logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
-    if (willMatch === "nothing") {
-      return [];
+    /**
+     * @param workspace - The address of the share the replica belongs to.
+     */
+    constructor(workspace: WorkspaceAddress) {
+        logger.debug("constructor");
+        this.workspace = workspace;
     }
 
-    // get history docs or all docs
-    logger.debug(`    getting docs; historyMode = ${query.historyMode}`);
-    let docs = query.historyMode === "all"
-      ? await this._getAllDocs() // don't sort it here,
-      : await this._getLatestDocs(); // we'll sort it below
+    //--------------------------------------------------
+    // LIFECYCLE
 
-    // orderBy
-    logger.debug(`    ordering docs: ${query.orderBy}`);
-    if (query.orderBy === "path ASC") {
-      docs.sort(docComparePathASCthenNewestFirst);
-    } else if (query.orderBy === "path DESC") {
-      docs.sort(docComparePathDESCthenNewestFirst);
-    } else if (query.orderBy === "localIndex ASC") {
-      docs.sort(compareByObjKey("_localIndex", "ASC"));
-    } else if (query.orderBy === "localIndex DESC") {
-      docs.sort(compareByObjKey("_localIndex", "DESC"));
-    } else {
-      throw new ValidationError(
-        "unrecognized query orderBy: " + JSON.stringify(query.orderBy),
-      );
+    isClosed(): boolean {
+        return this._isClosed;
     }
-
-    let filteredDocs: Doc[] = [];
-    logger.debug(`    filtering docs`);
-    for (let doc of docs) {
-      // skip ahead until we reach startAfter
-      if (query.orderBy === "path ASC") {
-        if (query.startAfter !== undefined) {
-          if (
-            query.startAfter.path !== undefined &&
-            doc.path <= query.startAfter.path
-          ) {
-            continue;
-          }
-          // doc.path is now > startAfter.path
+    close(erase: boolean) {
+        logger.debug("close");
+        if (this._isClosed) throw new StorageIsClosedError();
+        if (erase) {
+            logger.debug("...close: and erase");
+            // this is an in-memory store so we don't really need to delete anything,
+            // but this might help free up memory for the garbage collector
+            this._configKv = {};
+            this._maxLocalIndex = -1;
+            this.docsByPathNewestFirst.clear();
+            this.docByPathAndAuthor.clear();
         }
-      }
-      if (query.orderBy === "path DESC") {
-        if (query.startAfter !== undefined) {
-          if (
-            query.startAfter.path !== undefined &&
-            doc.path >= query.startAfter.path
-          ) {
-            continue;
-          }
-          // doc.path is now < startAfter.path (we're descending)
-        }
-      }
-      if (query.orderBy === "localIndex ASC") {
-        if (query.startAfter !== undefined) {
-          if (
-            query.startAfter.localIndex !== undefined &&
-            (doc._localIndex ?? 0) <= query.startAfter.localIndex
-          ) {
-            continue;
-          }
-          // doc.path is now > startAfter.localIndex
-        }
-      }
-      if (query.orderBy === "localIndex DESC") {
-        if (query.startAfter !== undefined) {
-          if (
-            query.startAfter.localIndex !== undefined &&
-            (doc._localIndex ?? 0) >= query.startAfter.localIndex
-          ) {
-            continue;
-          }
-          // doc.path is now < startAfter.localIndex (we're descending)
-        }
-      }
+        this._isClosed = true;
+        logger.debug("...close is done.");
 
-      // apply filter: skip docs that don't match
-      if (query.filter && !docMatchesFilter(doc, query.filter)) continue;
-
-      // finally, here's a doc we want
-      filteredDocs.push(doc);
-
-      // stop when hitting limit
-      if (
-        query.limit !== undefined && filteredDocs.length >= query.limit
-      ) {
-        logger.debug(`    ....hit limit of ${query.limit}`);
-        break;
-      }
+        return Promise.resolve();
     }
 
-    logger.debug(
-      `    queryDocs is done: found ${filteredDocs.length} docs.`,
-    );
-    return filteredDocs;
-  }
+    //--------------------------------------------------
+    // CONFIG
 
-  //--------------------------------------------------
-  // SET
+    async getConfig(key: string): Promise<string | undefined> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return this._configKv[key];
+    }
+    async setConfig(key: string, value: string): Promise<void> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        this._configKv[key] = value;
+    }
+    async listConfigKeys(): Promise<string[]> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        return sortedInPlace(Object.keys(this._configKv));
+    }
+    async deleteConfig(key: string): Promise<boolean> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        let had = (key in this._configKv);
+        delete this._configKv[key];
+        return had;
+    }
 
-  async upsert(doc: Doc): Promise<Doc> {
-    // add a doc.  don't enforce any rules on it.
-    // overwrite existing doc even if this doc is older.
-    // return a copy of the doc, frozen, with _localIndex set.
+    //--------------------------------------------------
+    // GET
 
-    if (this._isClosed) throw new StorageIsClosedError();
+    getMaxLocalIndex() {
+        if (this._isClosed) throw new StorageIsClosedError();
+        logger.debug(`getMaxLocalIndex(): it's ${this._maxLocalIndex}`);
+        return this._maxLocalIndex;
+    }
 
-    doc = { ...doc };
-    this._maxLocalIndex += 1; // this starts at -1 initially, so the first doc has a localIndex of 0.
-    doc._localIndex = this._maxLocalIndex;
-    Object.freeze(doc);
-    logger.debug("upsert", doc);
+    async _getAllDocs(): Promise<Doc[]> {
+        // return in unsorted order
+        if (this._isClosed) throw new StorageIsClosedError();
+        return [...this.docByPathAndAuthor.values()];
+    }
+    async _getLatestDocs(): Promise<Doc[]> {
+        // return in unsorted order
+        if (this._isClosed) throw new StorageIsClosedError();
+        let docs: Doc[] = [];
+        for (let docArray of this.docsByPathNewestFirst.values()) {
+            // this array is kept sorted newest-first
+            docs.push(docArray[0]);
+        }
+        return docs;
+    }
 
-    // save into our various indexes and data structures
+    async queryDocs(queryToClean: Query): Promise<Doc[]> {
+        // Query the documents.
 
-    this.docByPathAndAuthor.set(combinePathAndAuthor(doc), doc);
+        logger.debug("queryDocs", queryToClean);
+        if (this._isClosed) throw new StorageIsClosedError();
 
-    // get list of history docs at this path
-    let docsByPath = this.docsByPathNewestFirst.get(doc.path) ?? [];
-    // remove existing doc from same author same path
-    docsByPath = docsByPath.filter((d) => d.author !== doc.author);
-    // add this new doc
-    docsByPath.push(doc);
-    // sort newest first within this path
-    docsByPath.sort(docComparePathASCthenNewestFirst);
-    // save the list back to the index
-    this.docsByPathNewestFirst.set(doc.path, docsByPath);
+        // clean up the query and exit early if possible.
+        let { query, willMatch } = cleanUpQuery(queryToClean);
+        logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
+        if (willMatch === "nothing") {
+            return [];
+        }
 
-    return doc;
-  }
+        // get history docs or all docs
+        logger.debug(`    getting docs; historyMode = ${query.historyMode}`);
+        let docs = query.historyMode === "all"
+            ? await this._getAllDocs() // don't sort it here,
+            : await this._getLatestDocs(); // we'll sort it below
+
+        // orderBy
+        logger.debug(`    ordering docs: ${query.orderBy}`);
+        if (query.orderBy === "path ASC") {
+            docs.sort(docComparePathASCthenNewestFirst);
+        } else if (query.orderBy === "path DESC") {
+            docs.sort(docComparePathDESCthenNewestFirst);
+        } else if (query.orderBy === "localIndex ASC") {
+            docs.sort(compareByObjKey("_localIndex", "ASC"));
+        } else if (query.orderBy === "localIndex DESC") {
+            docs.sort(compareByObjKey("_localIndex", "DESC"));
+        } else {
+            throw new ValidationError(
+                "unrecognized query orderBy: " + JSON.stringify(query.orderBy),
+            );
+        }
+
+        let filteredDocs: Doc[] = [];
+        logger.debug(`    filtering docs`);
+        for (let doc of docs) {
+            // skip ahead until we reach startAfter
+            if (query.orderBy === "path ASC") {
+                if (query.startAfter !== undefined) {
+                    if (
+                        query.startAfter.path !== undefined &&
+                        doc.path <= query.startAfter.path
+                    ) {
+                        continue;
+                    }
+                    // doc.path is now > startAfter.path
+                }
+            }
+            if (query.orderBy === "path DESC") {
+                if (query.startAfter !== undefined) {
+                    if (
+                        query.startAfter.path !== undefined &&
+                        doc.path >= query.startAfter.path
+                    ) {
+                        continue;
+                    }
+                    // doc.path is now < startAfter.path (we're descending)
+                }
+            }
+            if (query.orderBy === "localIndex ASC") {
+                if (query.startAfter !== undefined) {
+                    if (
+                        query.startAfter.localIndex !== undefined &&
+                        (doc._localIndex ?? 0) <= query.startAfter.localIndex
+                    ) {
+                        continue;
+                    }
+                    // doc.path is now > startAfter.localIndex
+                }
+            }
+            if (query.orderBy === "localIndex DESC") {
+                if (query.startAfter !== undefined) {
+                    if (
+                        query.startAfter.localIndex !== undefined &&
+                        (doc._localIndex ?? 0) >= query.startAfter.localIndex
+                    ) {
+                        continue;
+                    }
+                    // doc.path is now < startAfter.localIndex (we're descending)
+                }
+            }
+
+            // apply filter: skip docs that don't match
+            if (query.filter && !docMatchesFilter(doc, query.filter)) continue;
+
+            // finally, here's a doc we want
+            filteredDocs.push(doc);
+
+            // stop when hitting limit
+            if (
+                query.limit !== undefined && filteredDocs.length >= query.limit
+            ) {
+                logger.debug(`    ....hit limit of ${query.limit}`);
+                break;
+            }
+        }
+
+        logger.debug(
+            `    queryDocs is done: found ${filteredDocs.length} docs.`,
+        );
+        return filteredDocs;
+    }
+
+    //--------------------------------------------------
+    // SET
+
+    async upsert(doc: Doc): Promise<Doc> {
+        // add a doc.  don't enforce any rules on it.
+        // overwrite existing doc even if this doc is older.
+        // return a copy of the doc, frozen, with _localIndex set.
+
+        if (this._isClosed) throw new StorageIsClosedError();
+
+        doc = { ...doc };
+        this._maxLocalIndex += 1; // this starts at -1 initially, so the first doc has a localIndex of 0.
+        doc._localIndex = this._maxLocalIndex;
+        Object.freeze(doc);
+        logger.debug("upsert", doc);
+
+        // save into our various indexes and data structures
+
+        this.docByPathAndAuthor.set(combinePathAndAuthor(doc), doc);
+
+        // get list of history docs at this path
+        let docsByPath = this.docsByPathNewestFirst.get(doc.path) ?? [];
+        // remove existing doc from same author same path
+        docsByPath = docsByPath.filter((d) => d.author !== doc.author);
+        // add this new doc
+        docsByPath.push(doc);
+        // sort newest first within this path
+        docsByPath.sort(docComparePathASCthenNewestFirst);
+        // save the list back to the index
+        this.docsByPathNewestFirst.set(doc.path, docsByPath);
+
+        return doc;
+    }
 }

--- a/src/storage/storage-driver-indexeddb.ts
+++ b/src/storage/storage-driver-indexeddb.ts
@@ -19,266 +19,266 @@ const CONFIG_STORE = "config";
  * Works in browsers.
  */
 export class StorageDriverIndexedDB extends StorageDriverAsyncMemory {
-  _db: IDBDatabase | null = null;
+    _db: IDBDatabase | null = null;
 
-  /**
-   * @param workspace - The address of the share the replica belongs to.
-   */
-  constructor(workspace: WorkspaceAddress) {
-    super(workspace);
-    logger.debug("constructor");
+    /**
+     * @param workspace - The address of the share the replica belongs to.
+     */
+    constructor(workspace: WorkspaceAddress) {
+        super(workspace);
+        logger.debug("constructor");
 
-    this.docByPathAndAuthor = new Map();
-    this.docsByPathNewestFirst = new Map();
-  }
-
-  getIndexedDb(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-      if (this._db) {
-        return resolve(this._db);
-      }
-
-      // dnt-shim-ignore
-      if (!(window as any).indexedDB) {
-        return reject();
-      }
-
-      // Deno doesn't have indexedDB yet, so we need to cast as any.
-      // dnt-shim-ignore
-      const request = (window as any).indexedDB.open(
-        `stonesoup:database:${this.workspace}`,
-        1,
-      );
-
-      request.onerror = () => {
-        logger.error(`Could not open IndexedDB for ${this.workspace}`);
-        logger.error(request.error);
-      };
-
-      request.onupgradeneeded = function () {
-        const db = request.result;
-
-        // we're going to store everything in one row.
-        db.createObjectStore(DOC_STORE, { keyPath: "id" });
-        db.createObjectStore(CONFIG_STORE, { keyPath: "key" });
-      };
-
-      request.onsuccess = () => {
-        this._db = request.result;
-
-        const transaction = request.result.transaction(
-          [DOC_STORE],
-          "readonly",
-        );
-
-        const store = transaction.objectStore(DOC_STORE);
-        const retrieval = store.get(DOCUMENTS_ID);
-
-        retrieval.onsuccess = () => {
-          const docs = retrieval.result;
-
-          if (!docs) {
-            return resolve(request.result);
-          }
-
-          this.docByPathAndAuthor = new Map(
-            Object.entries(docs.byPathAndAuthor),
-          );
-          this.docsByPathNewestFirst = new Map(
-            Object.entries(docs.byPathNewestFirst),
-          );
-
-          return resolve(request.result);
-        };
-
-        retrieval.onerror = () => {
-          logger.debug(
-            `StorageIndexedDB constructing: No existing DB for ${this.workspace}`,
-          );
-          reject();
-        };
-      };
-    });
-  }
-
-  //--------------------------------------------------
-  // LIFECYCLE
-
-  // isClosed(): inherited
-  async close(erase: boolean): Promise<void> {
-    logger.debug("close");
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
-    }
-    if (erase) {
-      logger.debug("...close: and erase");
-      this._configKv = {};
-      this._maxLocalIndex = -1;
-      this.docsByPathNewestFirst.clear();
-      this.docByPathAndAuthor.clear();
-
-      logger.debug("...close: erasing indexeddb");
-
-      const db = await this.getIndexedDb();
-
-      for (let key of await this.listConfigKeys()) {
-        await this.deleteConfig(key);
-      }
-
-      const deletion = db
-        .transaction(DOC_STORE, "readwrite")
-        .objectStore(DOC_STORE)
-        .delete(DOCUMENTS_ID);
-
-      deletion.onsuccess = () => {
-        logger.debug("...close: erasing is done");
-      };
-    }
-    this._isClosed = true;
-    logger.debug("...close is done.");
-  }
-
-  //--------------------------------------------------
-  // CONFIG
-
-  async getConfig(key: string): Promise<string | undefined> {
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
+        this.docByPathAndAuthor = new Map();
+        this.docsByPathNewestFirst = new Map();
     }
 
-    const db = await this.getIndexedDb();
+    getIndexedDb(): Promise<IDBDatabase> {
+        return new Promise((resolve, reject) => {
+            if (this._db) {
+                return resolve(this._db);
+            }
 
-    return new Promise((resolve, reject) => {
-      const retrieval = db
-        .transaction(CONFIG_STORE, "readonly")
-        .objectStore(CONFIG_STORE)
-        .get(key);
+            // dnt-shim-ignore
+            if (!(window as any).indexedDB) {
+                return reject();
+            }
 
-      retrieval.onsuccess = () => {
-        if (!retrieval.result) {
-          return resolve(undefined);
+            // Deno doesn't have indexedDB yet, so we need to cast as any.
+            // dnt-shim-ignore
+            const request = (window as any).indexedDB.open(
+                `stonesoup:database:${this.workspace}`,
+                1,
+            );
+
+            request.onerror = () => {
+                logger.error(`Could not open IndexedDB for ${this.workspace}`);
+                logger.error(request.error);
+            };
+
+            request.onupgradeneeded = function () {
+                const db = request.result;
+
+                // we're going to store everything in one row.
+                db.createObjectStore(DOC_STORE, { keyPath: "id" });
+                db.createObjectStore(CONFIG_STORE, { keyPath: "key" });
+            };
+
+            request.onsuccess = () => {
+                this._db = request.result;
+
+                const transaction = request.result.transaction(
+                    [DOC_STORE],
+                    "readonly",
+                );
+
+                const store = transaction.objectStore(DOC_STORE);
+                const retrieval = store.get(DOCUMENTS_ID);
+
+                retrieval.onsuccess = () => {
+                    const docs = retrieval.result;
+
+                    if (!docs) {
+                        return resolve(request.result);
+                    }
+
+                    this.docByPathAndAuthor = new Map(
+                        Object.entries(docs.byPathAndAuthor),
+                    );
+                    this.docsByPathNewestFirst = new Map(
+                        Object.entries(docs.byPathNewestFirst),
+                    );
+
+                    return resolve(request.result);
+                };
+
+                retrieval.onerror = () => {
+                    logger.debug(
+                        `StorageIndexedDB constructing: No existing DB for ${this.workspace}`,
+                    );
+                    reject();
+                };
+            };
+        });
+    }
+
+    //--------------------------------------------------
+    // LIFECYCLE
+
+    // isClosed(): inherited
+    async close(erase: boolean): Promise<void> {
+        logger.debug("close");
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        if (erase) {
+            logger.debug("...close: and erase");
+            this._configKv = {};
+            this._maxLocalIndex = -1;
+            this.docsByPathNewestFirst.clear();
+            this.docByPathAndAuthor.clear();
+
+            logger.debug("...close: erasing indexeddb");
+
+            const db = await this.getIndexedDb();
+
+            for (let key of await this.listConfigKeys()) {
+                await this.deleteConfig(key);
+            }
+
+            const deletion = db
+                .transaction(DOC_STORE, "readwrite")
+                .objectStore(DOC_STORE)
+                .delete(DOCUMENTS_ID);
+
+            deletion.onsuccess = () => {
+                logger.debug("...close: erasing is done");
+            };
+        }
+        this._isClosed = true;
+        logger.debug("...close is done.");
+    }
+
+    //--------------------------------------------------
+    // CONFIG
+
+    async getConfig(key: string): Promise<string | undefined> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
         }
 
-        return resolve(retrieval.result.value);
-      };
+        const db = await this.getIndexedDb();
 
-      retrieval.onerror = () => {
-        reject(retrieval.error);
-      };
-    });
-  }
-  async setConfig(key: string, value: string): Promise<void> {
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
-    }
+        return new Promise((resolve, reject) => {
+            const retrieval = db
+                .transaction(CONFIG_STORE, "readonly")
+                .objectStore(CONFIG_STORE)
+                .get(key);
 
-    const db = await this.getIndexedDb();
+            retrieval.onsuccess = () => {
+                if (!retrieval.result) {
+                    return resolve(undefined);
+                }
 
-    return new Promise((resolve, reject) => {
-      const set = db
-        .transaction(CONFIG_STORE, "readwrite")
-        .objectStore(CONFIG_STORE)
-        .put({ key, value });
+                return resolve(retrieval.result.value);
+            };
 
-      set.onsuccess = () => {
-        resolve();
-      };
-
-      set.onerror = () => {
-        reject();
-      };
-    });
-  }
-  async listConfigKeys(): Promise<string[]> {
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
-    }
-
-    const db = await this.getIndexedDb();
-
-    return new Promise((resolve, reject) => {
-      const getKeys = db
-        .transaction(CONFIG_STORE, "readonly")
-        .objectStore(CONFIG_STORE)
-        .getAllKeys();
-
-      getKeys.onsuccess = () => {
-        resolve(getKeys.result.sort() as string[]);
-      };
-
-      getKeys.onerror = () => {
-        reject();
-      };
-    });
-  }
-
-  async deleteConfig(key: string): Promise<boolean> {
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
-    }
-
-    const db = await this.getIndexedDb();
-
-    const hadIt = (await this.getConfig(key)) !== undefined;
-
-    return new Promise((resolve, reject) => {
-      const deletion = db
-        .transaction(CONFIG_STORE, "readwrite")
-        .objectStore(CONFIG_STORE)
-        .delete(key);
-
-      deletion.onsuccess = () => {
-        resolve(hadIt);
-      };
-
-      deletion.onerror = () => {
-        reject();
-      };
-    });
-  }
-
-  //--------------------------------------------------
-  // GET
-
-  // getMaxLocalIndex(): inherited
-  // queryDocs(query: Query): inherited
-
-  //--------------------------------------------------
-  // SET
-
-  async upsert(doc: Doc): Promise<Doc> {
-    if (this._isClosed) {
-      throw new StorageIsClosedError();
-    }
-    let upsertedDoc = await super.upsert(doc);
-
-    // After every upsert, for now, we save everything
-    // to IndexedDB as a single giant blob.
-    // TODO: debounce this, only do it every 1 second or something
-
-    const docs = {
-      byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
-      byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
-    };
-
-    const db = await this.getIndexedDb();
-
-    return new Promise((resolve, reject) => {
-      const put = db
-        .transaction(DOC_STORE, "readwrite")
-        .objectStore(DOC_STORE)
-        .put({
-          id: DOCUMENTS_ID,
-          docs,
+            retrieval.onerror = () => {
+                reject(retrieval.error);
+            };
         });
+    }
+    async setConfig(key: string, value: string): Promise<void> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
 
-      put.onsuccess = () => {
-        resolve(upsertedDoc);
-      };
+        const db = await this.getIndexedDb();
 
-      put.onerror = () => {
-        reject();
-      };
-    });
-  }
+        return new Promise((resolve, reject) => {
+            const set = db
+                .transaction(CONFIG_STORE, "readwrite")
+                .objectStore(CONFIG_STORE)
+                .put({ key, value });
+
+            set.onsuccess = () => {
+                resolve();
+            };
+
+            set.onerror = () => {
+                reject();
+            };
+        });
+    }
+    async listConfigKeys(): Promise<string[]> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        const db = await this.getIndexedDb();
+
+        return new Promise((resolve, reject) => {
+            const getKeys = db
+                .transaction(CONFIG_STORE, "readonly")
+                .objectStore(CONFIG_STORE)
+                .getAllKeys();
+
+            getKeys.onsuccess = () => {
+                resolve(getKeys.result.sort() as string[]);
+            };
+
+            getKeys.onerror = () => {
+                reject();
+            };
+        });
+    }
+
+    async deleteConfig(key: string): Promise<boolean> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        const db = await this.getIndexedDb();
+
+        const hadIt = (await this.getConfig(key)) !== undefined;
+
+        return new Promise((resolve, reject) => {
+            const deletion = db
+                .transaction(CONFIG_STORE, "readwrite")
+                .objectStore(CONFIG_STORE)
+                .delete(key);
+
+            deletion.onsuccess = () => {
+                resolve(hadIt);
+            };
+
+            deletion.onerror = () => {
+                reject();
+            };
+        });
+    }
+
+    //--------------------------------------------------
+    // GET
+
+    // getMaxLocalIndex(): inherited
+    // queryDocs(query: Query): inherited
+
+    //--------------------------------------------------
+    // SET
+
+    async upsert(doc: Doc): Promise<Doc> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        let upsertedDoc = await super.upsert(doc);
+
+        // After every upsert, for now, we save everything
+        // to IndexedDB as a single giant blob.
+        // TODO: debounce this, only do it every 1 second or something
+
+        const docs = {
+            byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
+            byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
+        };
+
+        const db = await this.getIndexedDb();
+
+        return new Promise((resolve, reject) => {
+            const put = db
+                .transaction(DOC_STORE, "readwrite")
+                .objectStore(DOC_STORE)
+                .put({
+                    id: DOCUMENTS_ID,
+                    docs,
+                });
+
+            put.onsuccess = () => {
+                resolve(upsertedDoc);
+            };
+
+            put.onerror = () => {
+                reject();
+            };
+        });
+    }
 }

--- a/src/storage/storage-driver-local-storage.ts
+++ b/src/storage/storage-driver-local-storage.ts
@@ -9,168 +9,167 @@ let logger = new Logger("storage driver localStorage", "yellowBright");
 
 //================================================================================
 type SerializedDriverDocs = {
-  byPathAndAuthor: Record<string, Doc>;
-  byPathNewestFirst: Record<Path, Doc[]>;
+    byPathAndAuthor: Record<string, Doc>;
+    byPathNewestFirst: Record<Path, Doc[]>;
 };
 
 function isSerializedDriverDocs(value: any): value is SerializedDriverDocs {
-  // check if data we've loaded from localStorage is actually in the format we expect
-  if (typeof value !== "object") {
-    return false;
-  }
-  return ("byPathAndAuthor" in value && "byPathNewestFirst" in value);
+    // check if data we've loaded from localStorage is actually in the format we expect
+    if (typeof value !== "object") {
+        return false;
+    }
+    return ("byPathAndAuthor" in value && "byPathNewestFirst" in value);
 }
 
 /** A storage driver which perists to LocalStorage, which stores a maximum of five megabytes per domain. If you're storing multiple shares, this limit will be divided among all their replicas.
  * Works in browsers and Deno.
  */
 export class StorageDriverLocalStorage extends StorageDriverAsyncMemory {
-  _localStorageKeyConfig: string;
-  _localStorageKeyDocs: string;
+    _localStorageKeyConfig: string;
+    _localStorageKeyDocs: string;
 
-  /**
-   * @param workspace - The address of the share the replica belongs to.
-   */
-  constructor(workspace: WorkspaceAddress) {
-    super(workspace);
-    logger.debug("constructor");
+    /**
+     * @param workspace - The address of the share the replica belongs to.
+     */
+    constructor(workspace: WorkspaceAddress) {
+        super(workspace);
+        logger.debug("constructor");
 
-    // each config item starts with this prefix and gets its own entry in localstorage
-    this._localStorageKeyConfig = `stonesoup:config:${workspace}`; // TODO: change this to "earthstar:..." later
-    // but all docs are stored together inside this one item, as a giant JSON object
-    this._localStorageKeyDocs =
-      `stonesoup:documents:pathandauthor:${workspace}`;
+        // each config item starts with this prefix and gets its own entry in localstorage
+        this._localStorageKeyConfig = `stonesoup:config:${workspace}`; // TODO: change this to "earthstar:..." later
+        // but all docs are stored together inside this one item, as a giant JSON object
+        this._localStorageKeyDocs = `stonesoup:documents:pathandauthor:${workspace}`;
 
-    let existingData = localStorage.getItem(this._localStorageKeyDocs);
-    if (existingData !== null) {
-      logger.debug("...constructor: loading data from localStorage");
-      let parsed = JSON.parse(existingData);
+        let existingData = localStorage.getItem(this._localStorageKeyDocs);
+        if (existingData !== null) {
+            logger.debug("...constructor: loading data from localStorage");
+            let parsed = JSON.parse(existingData);
 
-      if (!isSerializedDriverDocs(parsed)) {
-        console.warn(
-          `localStorage data could not be parsed for workspace ${workspace}`,
+            if (!isSerializedDriverDocs(parsed)) {
+                console.warn(
+                    `localStorage data could not be parsed for workspace ${workspace}`,
+                );
+                return;
+            }
+
+            this.docByPathAndAuthor = new Map(
+                Object.entries(parsed.byPathAndAuthor),
+            );
+            this.docsByPathNewestFirst = new Map(
+                Object.entries(parsed.byPathNewestFirst),
+            );
+        } else {
+            logger.debug(
+                "...constructor: there was no existing data in localStorage",
+            );
+        }
+        logger.debug("...constructor is done.");
+    }
+
+    //--------------------------------------------------
+    // LIFECYCLE
+
+    // isClosed(): inherited
+    close(erase: boolean) {
+        logger.debug("close");
+        if (this._isClosed) throw new StorageIsClosedError();
+        if (erase) {
+            logger.debug("...close: and erase");
+            this._configKv = {};
+            this._maxLocalIndex = -1;
+            this.docsByPathNewestFirst.clear();
+            this.docByPathAndAuthor.clear();
+
+            logger.debug("...close: erasing localStorage");
+            localStorage.removeItem(this._localStorageKeyDocs);
+            for (let key of this._listConfigKeysSync()) {
+                this._deleteConfigSync(key);
+            }
+            logger.debug("...close: erasing is done");
+        }
+        this._isClosed = true;
+        logger.debug("...close is done.");
+
+        return Promise.resolve();
+    }
+
+    //--------------------------------------------------
+    // CONFIG
+
+    // synchronous versions for internal use
+
+    _getConfigSync(key: string): string | undefined {
+        if (this._isClosed) throw new StorageIsClosedError();
+        key = `${this._localStorageKeyConfig}:${key}`;
+        let result = localStorage.getItem(key);
+        return result === null ? undefined : result;
+    }
+
+    _setConfigSync(key: string, value: string): void {
+        if (this._isClosed) throw new StorageIsClosedError();
+        key = `${this._localStorageKeyConfig}:${key}`;
+        localStorage.setItem(key, value);
+    }
+
+    _listConfigKeysSync(): string[] {
+        if (this._isClosed) throw new StorageIsClosedError();
+        let keys = Object.keys(localStorage)
+            .filter((key) => key.startsWith(this._localStorageKeyConfig + ":"))
+            .map((key) => key.slice(this._localStorageKeyConfig.length + 1));
+        keys.sort();
+        return keys;
+    }
+
+    _deleteConfigSync(key: string): boolean {
+        if (this._isClosed) throw new StorageIsClosedError();
+        let hadIt = this._getConfigSync(key);
+        key = `${this._localStorageKeyConfig}:${key}`;
+        localStorage.removeItem(key);
+        return hadIt !== undefined;
+    }
+
+    // async versions to match the IStorageDriverAsync interface
+
+    async getConfig(key: string): Promise<string | undefined> {
+        return this._getConfigSync(key);
+    }
+    async setConfig(key: string, value: string): Promise<void> {
+        return this._setConfigSync(key, value);
+    }
+    async listConfigKeys(): Promise<string[]> {
+        return this._listConfigKeysSync();
+    }
+    async deleteConfig(key: string): Promise<boolean> {
+        return this._deleteConfigSync(key);
+    }
+
+    //--------------------------------------------------
+    // GET
+
+    // getMaxLocalIndex(): inherited
+    // queryDocs(query: Query): inherited
+
+    //--------------------------------------------------
+    // SET
+
+    async upsert(doc: Doc): Promise<Doc> {
+        if (this._isClosed) throw new StorageIsClosedError();
+        let upsertedDoc = await super.upsert(doc);
+
+        // After every upsert, for now, we save everything
+        // to localStorage as a single giant JSON blob.
+        // TODO: debounce this, only do it every 1 second or something
+
+        const docsToBeSerialised: SerializedDriverDocs = {
+            byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
+            byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
+        };
+
+        localStorage.setItem(
+            this._localStorageKeyDocs,
+            JSON.stringify(docsToBeSerialised),
         );
-        return;
-      }
 
-      this.docByPathAndAuthor = new Map(
-        Object.entries(parsed.byPathAndAuthor),
-      );
-      this.docsByPathNewestFirst = new Map(
-        Object.entries(parsed.byPathNewestFirst),
-      );
-    } else {
-      logger.debug(
-        "...constructor: there was no existing data in localStorage",
-      );
+        return upsertedDoc;
     }
-    logger.debug("...constructor is done.");
-  }
-
-  //--------------------------------------------------
-  // LIFECYCLE
-
-  // isClosed(): inherited
-  close(erase: boolean) {
-    logger.debug("close");
-    if (this._isClosed) throw new StorageIsClosedError();
-    if (erase) {
-      logger.debug("...close: and erase");
-      this._configKv = {};
-      this._maxLocalIndex = -1;
-      this.docsByPathNewestFirst.clear();
-      this.docByPathAndAuthor.clear();
-
-      logger.debug("...close: erasing localStorage");
-      localStorage.removeItem(this._localStorageKeyDocs);
-      for (let key of this._listConfigKeysSync()) {
-        this._deleteConfigSync(key);
-      }
-      logger.debug("...close: erasing is done");
-    }
-    this._isClosed = true;
-    logger.debug("...close is done.");
-
-    return Promise.resolve();
-  }
-
-  //--------------------------------------------------
-  // CONFIG
-
-  // synchronous versions for internal use
-
-  _getConfigSync(key: string): string | undefined {
-    if (this._isClosed) throw new StorageIsClosedError();
-    key = `${this._localStorageKeyConfig}:${key}`;
-    let result = localStorage.getItem(key);
-    return result === null ? undefined : result;
-  }
-
-  _setConfigSync(key: string, value: string): void {
-    if (this._isClosed) throw new StorageIsClosedError();
-    key = `${this._localStorageKeyConfig}:${key}`;
-    localStorage.setItem(key, value);
-  }
-
-  _listConfigKeysSync(): string[] {
-    if (this._isClosed) throw new StorageIsClosedError();
-    let keys = Object.keys(localStorage)
-      .filter((key) => key.startsWith(this._localStorageKeyConfig + ":"))
-      .map((key) => key.slice(this._localStorageKeyConfig.length + 1));
-    keys.sort();
-    return keys;
-  }
-
-  _deleteConfigSync(key: string): boolean {
-    if (this._isClosed) throw new StorageIsClosedError();
-    let hadIt = this._getConfigSync(key);
-    key = `${this._localStorageKeyConfig}:${key}`;
-    localStorage.removeItem(key);
-    return hadIt !== undefined;
-  }
-
-  // async versions to match the IStorageDriverAsync interface
-
-  async getConfig(key: string): Promise<string | undefined> {
-    return this._getConfigSync(key);
-  }
-  async setConfig(key: string, value: string): Promise<void> {
-    return this._setConfigSync(key, value);
-  }
-  async listConfigKeys(): Promise<string[]> {
-    return this._listConfigKeysSync();
-  }
-  async deleteConfig(key: string): Promise<boolean> {
-    return this._deleteConfigSync(key);
-  }
-
-  //--------------------------------------------------
-  // GET
-
-  // getMaxLocalIndex(): inherited
-  // queryDocs(query: Query): inherited
-
-  //--------------------------------------------------
-  // SET
-
-  async upsert(doc: Doc): Promise<Doc> {
-    if (this._isClosed) throw new StorageIsClosedError();
-    let upsertedDoc = await super.upsert(doc);
-
-    // After every upsert, for now, we save everything
-    // to localStorage as a single giant JSON blob.
-    // TODO: debounce this, only do it every 1 second or something
-
-    const docsToBeSerialised: SerializedDriverDocs = {
-      byPathAndAuthor: Object.fromEntries(this.docByPathAndAuthor),
-      byPathNewestFirst: Object.fromEntries(this.docsByPathNewestFirst),
-    };
-
-    localStorage.setItem(
-      this._localStorageKeyDocs,
-      JSON.stringify(docsToBeSerialised),
-    );
-
-    return upsertedDoc;
-  }
 }

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -1,10 +1,10 @@
 import {
-  AuthorKeypair,
-  Doc,
-  DocToSet,
-  LocalIndex,
-  Path,
-  WorkspaceAddress,
+    AuthorKeypair,
+    Doc,
+    DocToSet,
+    LocalIndex,
+    Path,
+    WorkspaceAddress,
 } from "../util/doc-types.ts";
 import { HistoryMode, Query } from "../query/query-types.ts";
 import { IFormatValidator } from "../format-validators/format-validator-types.ts";
@@ -18,87 +18,87 @@ import { Superbus } from "../../deps.ts";
 export type StorageId = string;
 
 export type StorageBusChannel =
-  | "ingest"
-  | // 'write|/some/path.txt'  // note that write errors and no-ops are also sent here
-  "willClose"
-  | "didClose";
+    | "ingest"
+    | // 'write|/some/path.txt'  // note that write errors and no-ops are also sent here
+    "willClose"
+    | "didClose";
 
 export interface QueryResult {
-  // the docs from the query...
-  docs: Doc[];
-  // ...and the storageDriver's maxLocalIndex at the time
-  // just before and just after the query was done.
-  // This provided a lower and upper bound for the maxLocalIndex
-  // associated with the resulting docs.
-  // (This is the OVERALL max local index for
-  // the whole storage, not just for the resulting docs.)
-  maxLocalIndexBefore: number;
-  maxLocalIndexAfter: number;
-  // The max localIndex out of the returned docs.
-  // This could be much smaller than the overall maxLocalIndex
-  // if the docs have been filtered.
-  // If there are no matching docs, this is -1.
-  maxLocalIndexInResult: number;
+    // the docs from the query...
+    docs: Doc[];
+    // ...and the storageDriver's maxLocalIndex at the time
+    // just before and just after the query was done.
+    // This provided a lower and upper bound for the maxLocalIndex
+    // associated with the resulting docs.
+    // (This is the OVERALL max local index for
+    // the whole storage, not just for the resulting docs.)
+    maxLocalIndexBefore: number;
+    maxLocalIndexAfter: number;
+    // The max localIndex out of the returned docs.
+    // This could be much smaller than the overall maxLocalIndex
+    // if the docs have been filtered.
+    // If there are no matching docs, this is -1.
+    maxLocalIndexInResult: number;
 }
 
 // IngestEvents are returned from storage.set() and storage.ingest(),
 // and sent as events on the storage.bus 'ingest' channel.
 
 export interface IngestEventFailure {
-  kind: "failure";
-  reason: "write_error" | "invalid_document";
-  maxLocalIndex: number;
-  err: Error | null;
+    kind: "failure";
+    reason: "write_error" | "invalid_document";
+    maxLocalIndex: number;
+    err: Error | null;
 }
 export interface IngestEventNothingHappened {
-  kind: "nothing_happened";
-  reason: "obsolete_from_same_author" | "already_had_it";
-  maxLocalIndex: number;
-  doc: Doc; // won't have a _localIndex because it was not actually ingested
+    kind: "nothing_happened";
+    reason: "obsolete_from_same_author" | "already_had_it";
+    maxLocalIndex: number;
+    doc: Doc; // won't have a _localIndex because it was not actually ingested
 }
 export interface IngestEventSuccess {
-  kind: "success";
-  maxLocalIndex: number;
-  doc: Doc; // the just-written doc, frozen, with updated extra properties like _localIndex
+    kind: "success";
+    maxLocalIndex: number;
+    doc: Doc; // the just-written doc, frozen, with updated extra properties like _localIndex
 
-  docIsLatest: boolean; // is it the latest at this path (for any author)?
+    docIsLatest: boolean; // is it the latest at this path (for any author)?
 
-  // the most recent doc from the same author, at this path, before the new doc was written.
-  prevDocFromSameAuthor: Doc | null;
+    // the most recent doc from the same author, at this path, before the new doc was written.
+    prevDocFromSameAuthor: Doc | null;
 
-  // the latest doc from any author at this path, before the new doc was written.
-  // note this is actually still the latest doc if the just-written doc is an older one (docIsLatest===false)
-  prevLatestDoc: Doc | null;
+    // the latest doc from any author at this path, before the new doc was written.
+    // note this is actually still the latest doc if the just-written doc is an older one (docIsLatest===false)
+    prevLatestDoc: Doc | null;
 }
 export interface DocAlreadyExists {
-  // for a doc that was previously ingested, when a live query is catching up.
-  kind: "existing";
-  maxLocalIndex: number;
-  doc: Doc; // the just-written doc, frozen, with updated extra properties like _localIndex
+    // for a doc that was previously ingested, when a live query is catching up.
+    kind: "existing";
+    maxLocalIndex: number;
+    doc: Doc; // the just-written doc, frozen, with updated extra properties like _localIndex
 
-  //docIsLatest: boolean,  // is it the latest at this path (for any author)?
+    //docIsLatest: boolean,  // is it the latest at this path (for any author)?
 
-  //// the most recent doc from the same author, at this path, before the new doc was written.
-  //prevDocFromSameAuthor: Doc | null,
+    //// the most recent doc from the same author, at this path, before the new doc was written.
+    //prevDocFromSameAuthor: Doc | null,
 
-  //// the latest doc from any author at this path, before the new doc was written.
-  //// note this is actually still the latest doc if the just-written doc is an older one (docIsLatest===false)
-  //prevLatestDoc: Doc | null,
+    //// the latest doc from any author at this path, before the new doc was written.
+    //// note this is actually still the latest doc if the just-written doc is an older one (docIsLatest===false)
+    //prevLatestDoc: Doc | null,
 }
 export interface StorageEventWillClose {
-  kind: "willClose";
-  maxLocalIndex: number;
+    kind: "willClose";
+    maxLocalIndex: number;
 }
 export interface StorageEventDidClose {
-  kind: "didClose";
+    kind: "didClose";
 }
 
 export interface QueryFollowerDidClose {
-  kind: "queryFollowerDidClose";
+    kind: "queryFollowerDidClose";
 }
 
 export interface IdleEvent {
-  kind: "idle";
+    kind: "idle";
 }
 
 /**
@@ -107,9 +107,9 @@ export interface IdleEvent {
  * - IngestEventNothingHappened — ingested an obsolete or duplicate doc
  */
 export type IngestEvent =
-  | IngestEventFailure
-  | IngestEventNothingHappened
-  | IngestEventSuccess;
+    | IngestEventFailure
+    | IngestEventNothingHappened
+    | IngestEventSuccess;
 
 /**
  * - DocAlreadyExists — processing an old doc as you catch up
@@ -120,28 +120,28 @@ export type IngestEvent =
  * - QueryFollowerDidClose — the query follower was closed (can happen on its own or after the storage closes)
  */
 export type LiveQueryEvent =
-  | DocAlreadyExists
-  | // catching up...
-  IdleEvent
-  | // waiting for an ingest to happen...
-  IngestEvent
-  | // an ingest happened
-  StorageEventWillClose
-  | StorageEventDidClose
-  | QueryFollowerDidClose;
+    | DocAlreadyExists
+    | // catching up...
+    IdleEvent
+    | // waiting for an ingest to happen...
+    IngestEvent
+    | // an ingest happened
+    StorageEventWillClose
+    | StorageEventDidClose
+    | QueryFollowerDidClose;
 
 //================================================================================
 
 export interface IStorageAsyncConfigStorage {
-  // These methods will be mixed into the IStorageAsync.
-  // This is for local storage of configuration details for storage instances.
-  // This data will not be directly sync'd with other instances.
-  // Storage drivers implement these, and IStorageAsync just has stubs of
-  // these methods that call out to the storage driver.
-  getConfig(key: string): Promise<string | undefined>;
-  setConfig(key: string, value: string): Promise<void>;
-  listConfigKeys(): Promise<string[]>; // sorted
-  deleteConfig(key: string): Promise<boolean>;
+    // These methods will be mixed into the IStorageAsync.
+    // This is for local storage of configuration details for storage instances.
+    // This data will not be directly sync'd with other instances.
+    // Storage drivers implement these, and IStorageAsync just has stubs of
+    // these methods that call out to the storage driver.
+    getConfig(key: string): Promise<string | undefined>;
+    setConfig(key: string, value: string): Promise<void>;
+    listConfigKeys(): Promise<string[]>; // sorted
+    deleteConfig(key: string): Promise<boolean>;
 }
 
 /**
@@ -152,26 +152,26 @@ export interface IStorageAsyncConfigStorage {
  * ```
  */
 export interface IStorageAsync extends IStorageAsyncConfigStorage {
-  storageId: StorageId;
-  /** The address of the share this replica belongs to. */
-  workspace: WorkspaceAddress;
-  /** The validator used to validate ingested documents. */
-  formatValidator: IFormatValidator;
-  storageDriver: IStorageDriverAsync;
-  bus: Superbus<StorageBusChannel>;
+    storageId: StorageId;
+    /** The address of the share this replica belongs to. */
+    workspace: WorkspaceAddress;
+    /** The validator used to validate ingested documents. */
+    formatValidator: IFormatValidator;
+    storageDriver: IStorageDriverAsync;
+    bus: Superbus<StorageBusChannel>;
 
-  //--------------------------------------------------
-  // LIFECYCLE
+    //--------------------------------------------------
+    // LIFECYCLE
 
-  /** Returns whether the storage is closed or not. */
-  isClosed(): boolean;
+    /** Returns whether the storage is closed or not. */
+    isClosed(): boolean;
 
-  /**
-   * Closes the replica, preventing new documents from being ingested or events being emitted.
-   * Any methods called after closing will return `StorageIsClosedError`.
-   * @param erase - Erase the contents of the replica. Defaults to `false`.
-   */
-  /*
+    /**
+     * Closes the replica, preventing new documents from being ingested or events being emitted.
+     * Any methods called after closing will return `StorageIsClosedError`.
+     * @param erase - Erase the contents of the replica. Defaults to `false`.
+     */
+    /*
   More details:
 
   * send StorageWillClose events and wait for event receivers to finish blocking.
@@ -189,31 +189,31 @@ export interface IStorageAsync extends IStorageAsyncConfigStorage {
   If erase is true, actually delete and forget the local data (remove files, etc).
   Erase defaults to false if not provided.
   */
-  close(erase: boolean): Promise<void>;
+    close(erase: boolean): Promise<void>;
 
-  //--------------------------------------------------
-  // GET
+    //--------------------------------------------------
+    // GET
 
-  // this one is synchronous
-  /** Returns the max local index of all stored documents */
-  getMaxLocalIndex(): number;
+    // this one is synchronous
+    /** Returns the max local index of all stored documents */
+    getMaxLocalIndex(): number;
 
-  // these should all return frozen docs
-  getDocsAfterLocalIndex(
-    historyMode: HistoryMode,
-    startAfter: LocalIndex,
-    limit?: number,
-  ): Promise<Doc[]>;
-  /** Returns all documents, including historical versions of documents by other identities. */
-  getAllDocs(): Promise<Doc[]>;
-  /** Returns latest document from every path. */
-  getLatestDocs(): Promise<Doc[]>;
-  /** Returns all versions of a document by different authors from a specific path. */
-  getAllDocsAtPath(path: Path): Promise<Doc[]>;
-  /** Returns the most recently written version of a document at a path. */
-  getLatestDocAtPath(path: Path): Promise<Doc | undefined>;
+    // these should all return frozen docs
+    getDocsAfterLocalIndex(
+        historyMode: HistoryMode,
+        startAfter: LocalIndex,
+        limit?: number,
+    ): Promise<Doc[]>;
+    /** Returns all documents, including historical versions of documents by other identities. */
+    getAllDocs(): Promise<Doc[]>;
+    /** Returns latest document from every path. */
+    getLatestDocs(): Promise<Doc[]>;
+    /** Returns all versions of a document by different authors from a specific path. */
+    getAllDocsAtPath(path: Path): Promise<Doc[]>;
+    /** Returns the most recently written version of a document at a path. */
+    getLatestDocAtPath(path: Path): Promise<Doc | undefined>;
 
-  /** Returns an array of docs for a given query.
+    /** Returns an array of docs for a given query.
   ```
   const myQuery = {
     filter: {
@@ -225,80 +225,80 @@ export interface IStorageAsync extends IStorageAsyncConfigStorage {
   const firstFiveTextDocs = await myReplica.queryDocs(myQuery);
   ```
   */
-  queryDocs(query?: Query): Promise<Doc[]>;
+    queryDocs(query?: Query): Promise<Doc[]>;
 
-  //    queryPaths(query?: Query): Path[];
-  //    queryAuthors(query?: Query): AuthorAddress[];
+    //    queryPaths(query?: Query): Path[];
+    //    queryAuthors(query?: Query): AuthorAddress[];
 
-  //--------------------------------------------------
-  // SET
+    //--------------------------------------------------
+    // SET
 
-  /**
-   * Adds a new document to the replica. If a document signed by the same identity exists at the same path, it will be overwritten.
-   */
-  set(keypair: AuthorKeypair, docToSet: DocToSet): Promise<IngestEvent>;
+    /**
+     * Adds a new document to the replica. If a document signed by the same identity exists at the same path, it will be overwritten.
+     */
+    set(keypair: AuthorKeypair, docToSet: DocToSet): Promise<IngestEvent>;
 
-  /**
-   * Ingest an existing signed document to the replica.
-   */
-  // this should freeze the incoming doc if needed
-  ingest(doc: Doc): Promise<IngestEvent>;
+    /**
+     * Ingest an existing signed document to the replica.
+     */
+    // this should freeze the incoming doc if needed
+    ingest(doc: Doc): Promise<IngestEvent>;
 
-  /**
-   * Overwrite every document from this author, including history versions, with an empty doc.
-   */
-  // More:
-  // The new docs will have a timestamp of (oldDoc.timestamp + 1) to prevent them from
-  //  jumping to the front of the history and becoming Latest.
-  // Return the number of docs changed, or a ValidationError.
-  // Already-empty docs will not be overwritten.
-  // If an error occurs this will stop early.
-  overwriteAllDocsByAuthor(
-    keypair: AuthorKeypair,
-  ): Promise<number | ValidationError>;
+    /**
+     * Overwrite every document from this author, including history versions, with an empty doc.
+     */
+    // More:
+    // The new docs will have a timestamp of (oldDoc.timestamp + 1) to prevent them from
+    //  jumping to the front of the history and becoming Latest.
+    // Return the number of docs changed, or a ValidationError.
+    // Already-empty docs will not be overwritten.
+    // If an error occurs this will stop early.
+    overwriteAllDocsByAuthor(
+        keypair: AuthorKeypair,
+    ): Promise<number | ValidationError>;
 }
 
 /**
  * A storage driver provides low-level access to actual storage and is used by IStorageAsync to actually load and save data. StorageDrivers are not meant to be used directly by users; let the StorageAsync talk to it for you.
  */
 export interface IStorageDriverAsync extends IStorageAsyncConfigStorage {
-  workspace: WorkspaceAddress;
-  //--------------------------------------------------
-  // LIFECYCLE
+    workspace: WorkspaceAddress;
+    //--------------------------------------------------
+    // LIFECYCLE
 
-  /** Returns if the replica has been closed or not. */
-  isClosed(): boolean;
+    /** Returns if the replica has been closed or not. */
+    isClosed(): boolean;
 
-  /**
-   * Close the storageDriver.
-   * The Storage will call this.
-   * You cannot call close() if the storage is already closed (it will throw a StorageIsClosedError).
-   * If erase, actually delete and forget data locally.
-   * Erase defaults to false if not provided.
-   */
-  close(erase: boolean): Promise<void>;
+    /**
+     * Close the storageDriver.
+     * The Storage will call this.
+     * You cannot call close() if the storage is already closed (it will throw a StorageIsClosedError).
+     * If erase, actually delete and forget data locally.
+     * Erase defaults to false if not provided.
+     */
+    close(erase: boolean): Promise<void>;
 
-  //--------------------------------------------------
-  // GET
+    //--------------------------------------------------
+    // GET
 
-  /** The max local index used so far. */
-  // The first doc will increment this and get index 1.
-  // This is synchronous because it's expected that the driver will
-  // load it once at startup and then keep it in memory.
-  getMaxLocalIndex(): number;
+    /** The max local index used so far. */
+    // The first doc will increment this and get index 1.
+    // This is synchronous because it's expected that the driver will
+    // load it once at startup and then keep it in memory.
+    getMaxLocalIndex(): number;
 
-  /** Returns an array of Docs given a Query. */
-  // these should return frozen docs
-  queryDocs(query: Query): Promise<Doc[]>; //    queryPaths(query: Query): Doc[];
-  // TODO: add a special getAllDocsAtPath for use by ingest?
+    /** Returns an array of Docs given a Query. */
+    // these should return frozen docs
+    queryDocs(query: Query): Promise<Doc[]>; //    queryPaths(query: Query): Doc[];
+    // TODO: add a special getAllDocsAtPath for use by ingest?
 
-  //--------------------------------------------------
-  // SET
+    //--------------------------------------------------
+    // SET
 
-  /** Add or update a signed document. */
-  // do no checks of any kind, just save it to the indexes
-  // add a doc.  don't enforce any rules on it.
-  // overwrite existing doc even if this doc is older.
-  // return a copy of the doc, frozen, with _localIndex set.
-  upsert(doc: Doc): Promise<Doc>;
+    /** Add or update a signed document. */
+    // do no checks of any kind, just save it to the indexes
+    // add a doc.  don't enforce any rules on it.
+    // overwrite existing doc even if this doc is older.
+    // return a copy of the doc, frozen, with _localIndex set.
+    upsert(doc: Doc): Promise<Doc>;
 }

--- a/src/util/doc-types.ts
+++ b/src/util/doc-types.ts
@@ -20,14 +20,14 @@ export type FormatName = string;
 
 /** An identity used to sign documents. */
 export interface AuthorKeypair {
-  address: AuthorAddress;
-  secret: string;
+    address: AuthorAddress;
+    secret: string;
 }
 
 export type ParsedAddress = {
-  address: AuthorAddress;
-  name: AuthorShortname;
-  pubkey: Base32String;
+    address: AuthorAddress;
+    name: AuthorShortname;
+    pubkey: Base32String;
 };
 
 //================================================================================
@@ -35,54 +35,54 @@ export type ParsedAddress = {
 
 /** Contains data written and signed by an identity. */
 export interface Doc {
-  /** Which document format the doc adheres to, e.g. `es.4`. */
-  format: string;
-  author: AuthorAddress;
-  content: string; // TODO: | null, when we have sparse mode
-  contentHash: string;
-  //contentLength: number,  // TODO: add for sparse mode, and enforce in the format validator
-  /** When the document should be deleted, as a UNIX timestamp in microseconds. */
-  deleteAfter: number | null;
-  path: Path;
-  /** Used to verify the authorship of the document. */
-  signature: Signature;
-  /** When the document was written, as a UNIX timestamp in microseconds (millionths of a second, e.g. `Date.now() * 1000`).*/
-  timestamp: Timestamp;
-  workspace: WorkspaceAddress;
-  // workspaceSignature: Signature,  // TODO: add for sparse mode
+    /** Which document format the doc adheres to, e.g. `es.4`. */
+    format: string;
+    author: AuthorAddress;
+    content: string; // TODO: | null, when we have sparse mode
+    contentHash: string;
+    //contentLength: number,  // TODO: add for sparse mode, and enforce in the format validator
+    /** When the document should be deleted, as a UNIX timestamp in microseconds. */
+    deleteAfter: number | null;
+    path: Path;
+    /** Used to verify the authorship of the document. */
+    signature: Signature;
+    /** When the document was written, as a UNIX timestamp in microseconds (millionths of a second, e.g. `Date.now() * 1000`).*/
+    timestamp: Timestamp;
+    workspace: WorkspaceAddress;
+    // workspaceSignature: Signature,  // TODO: add for sparse mode
 
-  // Local Index:
-  // Our docs form a linear sequence with gaps.
-  // When a doc is updated (same author, same path, new content), it moves to the
-  // end of the sequence and gets a new, higher localIndex.
-  // This sequence is specific to this local storage, affected by the order it received
-  // documents.
-  //
-  // It's useful during syncing so that other peers can say "give me everything that's
-  // changed since your localIndex 23".
-  //
-  // This is sent over the wire as part of a Doc so the receiver knows what to ask for next time,
-  // but it's then moved into a separate data structure like:
-  //    knownPeerMaxLocalIndexes:
-  //        peer111: 77
-  //        peer222: 140
-  // ...which helps us continue syncing with that specific peer next time.
-  //
-  // When we upsert the doc into our own storage, we discard the other peer's value
-  // and replace it with our own localIndex.
-  //
-  // The localIndex is not included in the doc's signature.
-  _localIndex?: LocalIndex;
+    // Local Index:
+    // Our docs form a linear sequence with gaps.
+    // When a doc is updated (same author, same path, new content), it moves to the
+    // end of the sequence and gets a new, higher localIndex.
+    // This sequence is specific to this local storage, affected by the order it received
+    // documents.
+    //
+    // It's useful during syncing so that other peers can say "give me everything that's
+    // changed since your localIndex 23".
+    //
+    // This is sent over the wire as part of a Doc so the receiver knows what to ask for next time,
+    // but it's then moved into a separate data structure like:
+    //    knownPeerMaxLocalIndexes:
+    //        peer111: 77
+    //        peer222: 140
+    // ...which helps us continue syncing with that specific peer next time.
+    //
+    // When we upsert the doc into our own storage, we discard the other peer's value
+    // and replace it with our own localIndex.
+    //
+    // The localIndex is not included in the doc's signature.
+    _localIndex?: LocalIndex;
 }
 
 /** A partial doc that is about to get written. The rest of the properties will be computed automatically. */
 export interface DocToSet {
-  /** The format the document adheres to, e.g. `es.4` */
-  format: string;
-  path: Path;
-  content: string;
-  /** A UNIX timestamp in microseconds indicating when the document was written. Determined automatically if omitted. */
-  timestamp?: number;
-  /** A UNIX timestamp in microseconds indicating when the document should be deleted by.*/
-  deleteAfter?: number | null;
+    /** The format the document adheres to, e.g. `es.4` */
+    format: string;
+    path: Path;
+    content: string;
+    /** A UNIX timestamp in microseconds indicating when the document was written. Determined automatically if omitted. */
+    timestamp?: number;
+    /** A UNIX timestamp in microseconds indicating when the document should be deleted by.*/
+    deleteAfter?: number | null;
 }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -7,34 +7,35 @@ export { fast_deep_equal as deepEqual } from "../../deps.ts";
 export const deepCopy = rfdc();
 
 export function microsecondNow() {
-  return Date.now() * 1000;
+    return Date.now() * 1000;
 }
 
 /** Returns a promise which is fulfilled after a given number of milliseconds. */
 export function sleep(ms: number) {
-  return new Promise((res, rej) => {
-    setTimeout(res, ms);
-  });
+    return new Promise((res, rej) => {
+        setTimeout(res, ms);
+    });
 }
 
 // TODO: better randomness here
 export function randomId(): string {
-  return "" + Math.random() + Math.random();
+    return "" + Math.random() + Math.random();
 }
 
 // replace all occurrences of substring "from" with "to"
 export function replaceAll(str: string, from: string, to: string): string {
-  return str.split(from).join(to);
+    return str.split(from).join(to);
 }
 
 // how many times does the character occur in the string?
-export function countChars(str: string, char: string) {
-  if (char.length != 1) {
-    throw new Error("char must have length 1 but is " + JSON.stringify(char));
-  }
-  return str.split(char).length - 1;
-}
 
-export function isObjectEmpty(obj: Object): Boolean {
-  return Object.keys(obj).length === 0;
-}
+export let countChars = (str: string, char: string) => {
+    if (char.length != 1) {
+        throw new Error("char must have length 1 but is " + JSON.stringify(char));
+    }
+    return str.split(char).length - 1;
+};
+
+export let isObjectEmpty = (obj: Object): Boolean => {
+    return Object.keys(obj).length === 0;
+};


### PR DESCRIPTION
## What's the problem you solved?

Previously we baked formatting options into a command in our Makefile. This did not integrate with LSPs, which would format files differently if you had the format on save option enabled.

## What solution are you recommending?

Deno 1.18 adds automatic detection of a deno.json configuration. I previously removed this as we were using it for build options which downstream dependents would be forced to duplicate. But if we only use it for formatting options then dependents need not know.

This means that formatting can be done with the standard `deno fmt`, and also works with other Deno tools (like the LSP).

You will need Deno 1.18 for this to work.
