### PR TITLE
Update CI to use Deno 1.18.0, remove old branch

### DIFF
--- a/.github/workflows/bundle.js.yml
+++ b/.github/workflows/bundle.js.yml
@@ -2,9 +2,9 @@ name: Bundle CI
 
 on:
   push:
-    branches: [main, esm-first]
+    branches: [main]
   pull_request:
-    branches: [main, esm-first]
+    branches: [main]
 
 jobs:
   build:
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["1.17.2"]
+        deno-version: ["1.18.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deno.js.yml
+++ b/.github/workflows/deno.js.yml
@@ -2,9 +2,9 @@ name: Deno CI
 
 on:
   push:
-    branches: [main, esm-first]
+    branches: [main]
   pull_request:
-    branches: [main, esm-first]
+    branches: [main]
 
 jobs:
   build:
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["1.17.2"]
+        deno-version: ["1.18.0"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: NPM + Node CI
 
 on:
   push:
-    branches: [main, esm-first]
+    branches: [main]
   pull_request:
-    branches: [main, esm-first]
+    branches: [main]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: ["14", "16"]
-        deno-version: ["1.17.2"]
+        deno-version: ["1.18.0"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Seeing if I can fix suddenly breaking browser builds using the latest version of Deno.

