### PR TITLE
Trying to fix web bundle CI, async test leak

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -8,5 +8,5 @@ export * as sha256_uint8array from "https://esm.sh/sha256-uint8array@0.10.3";
 export { Superbus } from "./src/superbus/superbus.ts";
 export { Simplebus } from "./src/superbus/simplebus.ts";
 export { SuperbusMap } from "./src/superbus_map/superbus_map.ts";
-export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/6e05e960522e6def6974769d5bff032eaed68685/mod.ts";
+export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts";
 export { Lock } from "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,5 @@
 export { default as chalk } from "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts";
 export { default as fast_deep_equal } from "https://esm.sh/fast-deep-equal@3.1.3";
-export * as dbly_linked_list from "https://cdn.skypack.dev/dbly-linked-list@0.3.5";
 export { default as fast_json_stable_stringify } from "https://esm.sh/fast-json-stable-stringify@2.1.0";
 export * as rfc4648 from "https://esm.sh/rfc4648@1.5.0";
 export * as sha256_uint8array from "https://esm.sh/sha256-uint8array@0.10.3";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,5 @@
 export { default as chalk } from "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts";
 export { default as fast_deep_equal } from "https://esm.sh/fast-deep-equal@3.1.3";
-export { default as rfdc } from "https://esm.sh/rfdc@1.3.0?dts";
 export * as dbly_linked_list from "https://cdn.skypack.dev/dbly-linked-list@0.3.5";
 export { default as fast_json_stable_stringify } from "https://esm.sh/fast-json-stable-stringify@2.1.0";
 export * as rfc4648 from "https://esm.sh/rfc4648@1.5.0";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -3,80 +3,79 @@ import { build } from "https://deno.land/x/dnt@0.15.0/mod.ts";
 await Deno.remove("npm", { recursive: true }).catch((_) => {});
 
 await build({
-  entryPoints: ["./mod.ts", "./src/entries/node.ts"],
-  outDir: "./npm",
-  shims: {
-    deno: {
-      test: "dev",
-    },
-    weakRef: true,
-    custom: [
-      {
-        package: {
-          name: "@ungap/structured-clone",
-          version: "0.3.4",
+    entryPoints: ["./mod.ts", "./src/entries/node.ts"],
+    outDir: "./npm",
+    shims: {
+        deno: {
+            test: "dev",
         },
-        globalNames: ["structuredClone"],
-      },
-    ],
-    customDev: [
-      {
-        package: {
-          name: "@types/ungap__structured-clone",
+        weakRef: true,
+        custom: [
+            {
+                package: {
+                    name: "@ungap/structured-clone",
+                    version: "0.3.4",
+                },
+                globalNames: ["structuredClone"],
+            },
+        ],
+        customDev: [
+            {
+                package: {
+                    name: "@types/ungap__structured-clone",
+                },
+                globalNames: [],
+            },
+            {
+                package: {
+                    name: "@types/chloride",
+                    version: "2.4.0",
+                },
+                globalNames: [],
+            },
+        ],
+    },
+    compilerOptions: {
+        // This is for Node v14 support
+        target: "ES2020",
+    },
+    mappings: {
+        "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts": {
+            name: "chalk",
+            version: "4.1.2",
         },
-        globalNames: [],
-      },
-      {
-        package: {
-          name: "@types/chloride",
-          version: "2.4.0",
+        "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts": {
+            name: "concurrency-friends",
+            version: "5.2.0",
         },
-        globalNames: [],
-      },
-    ],
-  },
-  compilerOptions: {
-    // This is for Node v14 support
-    target: "ES2020",
-  },
-  mappings: {
-    "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts": {
-      name: "chalk",
-      version: "4.1.2",
+        "./src/node/chloride.ts": {
+            name: "chloride",
+            version: "2.4.1",
+        },
+        "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts":
+            {
+                name: "@noble/ed25519",
+                version: "1.4.0",
+            },
     },
-    "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts": {
-      name: "concurrency-friends",
-      version: "5.2.0",
+    package: {
+        // package.json properties
+        name: "stone-soup",
+        version: Deno.args[0],
+        description: "A distributed, syncable key-value database",
+        license: "AGPL-3.0",
+        repository: {
+            type: "git",
+            url: "git+https://github.com/earthstar-project/stone-soup.git",
+        },
+        bugs: {
+            url: "https://github.com/earthstar-project/stone-soup/issues",
+        },
     },
-    "./src/node/chloride.ts": {
-      name: "chloride",
-      version: "2.4.1",
+    // tsc includes 'dom' as a lib, so doesn't need IndexedDB types
+    redirects: {
+        "./src/storage/indexeddb-types.deno.d.ts": "./src/storage/indexeddb-types.node.d.ts",
     },
-    "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts":
-      {
-        name: "@noble/ed25519",
-        version: "1.4.0",
-      },
-  },
-  package: {
-    // package.json properties
-    name: "stone-soup",
-    version: Deno.args[0],
-    description: "A distributed, syncable key-value database",
-    license: "AGPL-3.0",
-    repository: {
-      type: "git",
-      url: "git+https://github.com/earthstar-project/stone-soup.git",
-    },
-    bugs: {
-      url: "https://github.com/earthstar-project/stone-soup/issues",
-    },
-  },
-  // tsc includes 'dom' as a lib, so doesn't need IndexedDB types
-  redirects: {
-    "./src/storage/indexeddb-types.deno.d.ts":
-      "./src/storage/indexeddb-types.node.d.ts",
-  },
 });
 
 // post build steps

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -3,64 +3,65 @@ import { build } from "https://deno.land/x/dnt@0.15.0/mod.ts";
 await Deno.remove("npm", { recursive: true }).catch((_) => {});
 
 await build({
-    entryPoints: ["./mod.ts", "./src/entries/node.ts"],
-    outDir: "./npm",
-    shims: {
-        deno: {
-            test: "dev",
-        },
-        weakRef: true,
-        customDev: [
-            {
-                package: {
-                    name: "@types/chloride",
-                    version: "2.4.0",
-                },
-                globalNames: [],
-            },
-        ],
+  entryPoints: ["./mod.ts", "./src/entries/node.ts"],
+  outDir: "./npm",
+  shims: {
+    deno: {
+      test: "dev",
     },
-    compilerOptions: {
-        // This is for Node v14 support
-        target: "ES2020",
+    weakRef: true,
+    customDev: [
+      {
+        package: {
+          name: "@types/chloride",
+          version: "2.4.0",
+        },
+        globalNames: [],
+      },
+    ],
+  },
+  compilerOptions: {
+    // This is for Node v14 support
+    target: "ES2020",
+  },
+  mappings: {
+    "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts": {
+      name: "chalk",
+      version: "4.1.2",
     },
-    mappings: {
-        "https://deno.land/x/crayon_chalk_aliases@1.1.0/index.ts": {
-            name: "chalk",
-            version: "4.1.2",
-        },
-        "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts": {
-            name: "concurrency-friends",
-            version: "5.2.0",
-        },
-        "./src/node/chloride.ts": {
-            name: "chloride",
-            version: "2.4.1",
-        },
-        "https://raw.githubusercontent.com/sgwilym/noble-ed25519/6e05e960522e6def6974769d5bff032eaed68685/mod.ts":
-            {
-                name: "@noble/ed25519",
-                version: "1.4.0",
-            },
+    "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts": {
+      name: "concurrency-friends",
+      version: "5.2.0",
     },
-    package: {
-        // package.json properties
-        name: "stone-soup",
-        version: Deno.args[0],
-        description: "A distributed, syncable key-value database",
-        license: "AGPL-3.0",
-        repository: {
-            type: "git",
-            url: "git+https://github.com/earthstar-project/stone-soup.git",
-        },
-        bugs: {
-            url: "https://github.com/earthstar-project/stone-soup/issues",
-        },
+    "./src/node/chloride.ts": {
+      name: "chloride",
+      version: "2.4.1",
     },
-    // tsc includes 'dom' as a lib, so doesn't need IndexedDB types
-    redirects: {
-        "./src/storage/indexeddb-types.deno.d.ts": "./src/storage/indexeddb-types.node.d.ts",
+    "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts":
+      {
+        name: "@noble/ed25519",
+        version: "1.4.0",
+      },
+  },
+  package: {
+    // package.json properties
+    name: "stone-soup",
+    version: Deno.args[0],
+    description: "A distributed, syncable key-value database",
+    license: "AGPL-3.0",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/earthstar-project/stone-soup.git",
     },
+    bugs: {
+      url: "https://github.com/earthstar-project/stone-soup/issues",
+    },
+  },
+  // tsc includes 'dom' as a lib, so doesn't need IndexedDB types
+  redirects: {
+    "./src/storage/indexeddb-types.deno.d.ts":
+      "./src/storage/indexeddb-types.node.d.ts",
+  },
 });
 
 // post build steps

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -10,7 +10,22 @@ await build({
       test: "dev",
     },
     weakRef: true,
+    custom: [
+      {
+        package: {
+          name: "@ungap/structured-clone",
+          version: "0.3.4",
+        },
+        globalNames: ["structuredClone"],
+      },
+    ],
     customDev: [
+      {
+        package: {
+          name: "@types/ungap__structured-clone",
+        },
+        globalNames: [],
+      },
       {
         package: {
           name: "@types/chloride",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -16,16 +16,10 @@ await build({
                     name: "@ungap/structured-clone",
                     version: "0.3.4",
                 },
-                globalNames: ["structuredClone"],
+                globalNames: [{ name: "structuredClone", exportName: "default" }],
             },
         ],
         customDev: [
-            {
-                package: {
-                    name: "@types/ungap__structured-clone",
-                },
-                globalNames: [],
-            },
             {
                 package: {
                     name: "@types/chloride",

--- a/src/entries/node.ts
+++ b/src/entries/node.ts
@@ -1,2 +1,4 @@
+// @deno-types='../node/structuredclone.d.ts'
+
 export { CryptoDriverChloride } from "../crypto/crypto-driver-chloride.ts";
 export { CryptoDriverNode } from "../crypto/crypto-driver-node.js";

--- a/src/node/structuredclone.d.ts
+++ b/src/node/structuredclone.d.ts
@@ -1,0 +1,1 @@
+declare module "@ungap/structured-clone";

--- a/src/test/improved/query-follower.test.ts
+++ b/src/test/improved/query-follower.test.ts
@@ -41,7 +41,7 @@ function runQueryFollowerTests(scenario: TestScenario) {
 
         let workspace = "+gardening.abcde";
         let storage = makeStorage(workspace);
-        let author1 = Crypto.generateAuthorKeypair("onee");
+        let author1 = await Crypto.generateAuthorKeypair("onee");
         if (isErr(author1)) {
             await storage.close(true);
             assert(false, "generate author failed");
@@ -113,6 +113,7 @@ function runQueryFollowerTests(scenario: TestScenario) {
         }
 
         await storage.close(true);
+
         assertEquals(
             initialCryptoDriver,
             GlobalCryptoDriver,
@@ -278,6 +279,7 @@ function runQueryFollowerTests(scenario: TestScenario) {
         });
 
         loggerTest.debug("close the storage");
+        //await qf.close();
         await storage.close(true);
 
         loggerTest.debug("sleep so didClose has time to happen");
@@ -306,8 +308,6 @@ function runQueryFollowerTests(scenario: TestScenario) {
                 (initialCryptoDriver as any).name
             }, ended as ${(GlobalCryptoDriver as any).name}`,
         );
-
-        await qf.close();
     });
 
     Deno.test(SUBTEST_NAME + ": fuzz test", async () => {
@@ -370,7 +370,8 @@ function runQueryFollowerTests(scenario: TestScenario) {
         await addDocs(storage, keypair1, 41, 50);
 
         // TODO-DENO: closing the storage leaks async ops?
-        await qf.close();
+        //await qf.close();
+        await storage.close(true);
 
         let expectedItemsFound = [...Array(51).keys()];
         assertEquals(

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -22,7 +22,6 @@ export function randomId(): string {
 }
 
 // replace all occurrences of substring "from" with "to"
-
 export function replaceAll(str: string, from: string, to: string): string {
     return str.split(from).join(to);
 }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,10 +1,9 @@
-import { rfdc } from "../../deps.ts";
 export { fast_deep_equal as deepEqual } from "../../deps.ts";
 
 //================================================================================
 // TIME
 
-export const deepCopy = rfdc();
+export const deepCopy = structuredClone;
 
 export function microsecondNow() {
     return Date.now() * 1000;
@@ -23,19 +22,20 @@ export function randomId(): string {
 }
 
 // replace all occurrences of substring "from" with "to"
+
 export function replaceAll(str: string, from: string, to: string): string {
     return str.split(from).join(to);
 }
 
 // how many times does the character occur in the string?
 
-export let countChars = (str: string, char: string) => {
+export function countChars(str: string, char: string) {
     if (char.length != 1) {
         throw new Error("char must have length 1 but is " + JSON.stringify(char));
     }
     return str.split(char).length - 1;
-};
+}
 
-export let isObjectEmpty = (obj: Object): Boolean => {
+export function isObjectEmpty(obj: Object): Boolean {
     return Object.keys(obj).length === 0;
-};
+}


### PR DESCRIPTION
This PR attempts to fix the web bundle. It also makes the web bundle way smaller (300kb -> 219kb).

- Replaces `rfdc` with `structuredClone` (working on getting this polyfilled for npm)
- Updates my fork of noble/ed25519 to use webcrypto instead of some huge sha512 lib
- Awaits a promise in a query follower test which was causing async op leaks. 