### PR TITLE
make npm build put correct license in package.json

### DIFF
--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -57,7 +57,7 @@ await build({
         name: "stone-soup",
         version: Deno.args[0],
         description: "A distributed, syncable key-value database",
-        license: "AGPL-3.0",
+        license: "LGPL-3.0-only",
         repository: {
             type: "git",
             url: "git+https://github.com/earthstar-project/stone-soup.git",


### PR DESCRIPTION
Our LICENSE file says LGPL, but the package.json that is generated by the build script says AGPL.