### PR TITLE
Sqlite storage drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ npm:
 	deno run --allow-all scripts/build_npm.ts $(VERSION)
 	
 bundle:
-	deno bundle --no-check=remote ./mod.ts ./earthstar.bundle.js
+	deno bundle --no-check=remote ./mod.browser.ts ./earthstar.bundle.js
 	
 run-bundle:
 	deno run --allow-all ./earthstar.bundle.js --help

--- a/deps.ts
+++ b/deps.ts
@@ -8,4 +8,3 @@ export { Simplebus } from "./src/superbus/simplebus.ts";
 export { SuperbusMap } from "./src/superbus_map/superbus_map.ts";
 export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts";
 export { Lock } from "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts";
-export * as Sqlite from "https://deno.land/x/sqlite@v3.2.0/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -8,3 +8,4 @@ export { Simplebus } from "./src/superbus/simplebus.ts";
 export { SuperbusMap } from "./src/superbus_map/superbus_map.ts";
 export * as ed from "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts";
 export { Lock } from "https://cdn.skypack.dev/concurrency-friends@5.2.0?dts";
+export * as Sqlite from "https://deno.land/x/sqlite@v3.2.0/mod.ts";

--- a/mod.browser.ts
+++ b/mod.browser.ts
@@ -1,2 +1,2 @@
 export * from "./src/entries/universal.ts";
-export * from "./src/entries/deno.ts";
+export * from "./src/entries/browser.ts";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -27,6 +27,13 @@ await build({
                 },
                 globalNames: [],
             },
+            {
+                package: {
+                    name: "@types/better-sqlite3",
+                    version: "7.4.2",
+                },
+                globalNames: [],
+            },
         ],
     },
     compilerOptions: {
@@ -45,6 +52,10 @@ await build({
         "./src/node/chloride.ts": {
             name: "chloride",
             version: "2.4.1",
+        },
+        "https://esm.sh/better-sqlite3?dts": {
+            name: "better-sqlite3",
+            version: "7.5.0",
         },
         "https://raw.githubusercontent.com/sgwilym/noble-ed25519/7af9329476ff2f2a0e524a9f78e36d09704efc63/mod.ts":
             {
@@ -69,6 +80,8 @@ await build({
     // tsc includes 'dom' as a lib, so doesn't need IndexedDB types
     redirects: {
         "./src/storage/indexeddb-types.deno.d.ts": "./src/storage/indexeddb-types.node.d.ts",
+        "./src/storage/storage-driver-sqlite.deno.ts":
+            "./src/storage/storage-driver-sqlite.node.ts",
     },
 });
 

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -3,7 +3,7 @@ import { build } from "https://deno.land/x/dnt@0.16.1/mod.ts";
 await Deno.remove("npm", { recursive: true }).catch((_) => {});
 
 await build({
-    entryPoints: ["./mod.ts", "./src/entries/node.ts"],
+    entryPoints: ["./mod.ts", "./src/entries/node.ts", "./src/entries/browser.ts"],
     outDir: "./npm",
     shims: {
         deno: {

--- a/src/entries/deno.ts
+++ b/src/entries/deno.ts
@@ -1,0 +1,2 @@
+export { StorageDriverLocalStorage } from "../storage/storage-driver-local-storage.ts";
+export { StorageDriverSqlite } from "../storage/storage-driver-sqlite.deno.ts";

--- a/src/entries/node.ts
+++ b/src/entries/node.ts
@@ -2,3 +2,6 @@
 
 export { CryptoDriverChloride } from "../crypto/crypto-driver-chloride.ts";
 export { CryptoDriverNode } from "../crypto/crypto-driver-node.js";
+
+// Import path deliberately points to Deno version: this'll be switched out for the node version during NPM build.
+export { StorageDriverSqlite } from "../storage/storage-driver-sqlite.deno.ts";

--- a/src/storage/storage-async.ts
+++ b/src/storage/storage-async.ts
@@ -462,7 +462,7 @@ export class StorageAsync implements IStorageAsync {
         logger.debug(`overwriteAllDocsByAuthor("${keypair.address}")`);
         if (this._isClosed) throw new StorageIsClosedError();
         // TODO: do this in batches
-        let docsToOverwrite = await this.queryDocs({
+        const docsToOverwrite = await this.queryDocs({
             filter: { author: keypair.address },
             historyMode: "all",
         });
@@ -471,19 +471,19 @@ export class StorageAsync implements IStorageAsync {
         );
         let numOverwritten = 0;
         let numAlreadyEmpty = 0;
-        for (let doc of docsToOverwrite) {
+        for (const doc of docsToOverwrite) {
             if (doc.content.length === 0) {
                 numAlreadyEmpty += 1;
                 continue;
             }
 
             // remove extra fields
-            let cleanedResult = this.formatValidator.removeExtraFields(doc);
+            const cleanedResult = this.formatValidator.removeExtraFields(doc);
             if (isErr(cleanedResult)) return cleanedResult;
-            let cleanedDoc = cleanedResult.doc;
+            const cleanedDoc = cleanedResult.doc;
 
             // make new doc which is empty and just barely newer than the original
-            let emptyDoc: Doc = {
+            const emptyDoc: Doc = {
                 ...cleanedDoc,
                 content: "",
                 contentHash: await Crypto.sha256base32(""),
@@ -492,13 +492,13 @@ export class StorageAsync implements IStorageAsync {
             };
 
             // sign and ingest it
-            let signedDoc = await this.formatValidator.signDocument(
+            const signedDoc = await this.formatValidator.signDocument(
                 keypair,
                 emptyDoc,
             );
             if (isErr(signedDoc)) return signedDoc;
 
-            let ingestEvent = await this.ingest(signedDoc);
+            const ingestEvent = await this.ingest(signedDoc);
             if (ingestEvent.kind === "failure") {
                 return new ValidationError(
                     "ingestion error during overwriteAllDocsBySameAuthor: " +

--- a/src/storage/storage-driver-sqlite.deno.ts
+++ b/src/storage/storage-driver-sqlite.deno.ts
@@ -1,0 +1,693 @@
+import { Doc, WorkspaceAddress } from "../util/doc-types.ts";
+import { EarthstarError, StorageIsClosedError, ValidationError } from "../util/errors.ts";
+import { IStorageDriverAsync } from "./storage-types.ts";
+import { Sqlite } from "../../deps.ts";
+
+//--------------------------------------------------
+
+import { Logger } from "../util/log.ts";
+import { bytesToString, isBytes, stringToBytes } from "../util/bytes.ts";
+import { Query } from "../query/query-types.ts";
+import { cleanUpQuery } from "../query/query.ts";
+import { sortedInPlace } from "./compare.ts";
+
+const logger = new Logger("storage driver sqlite node", "yellow");
+
+interface StorageSqliteOptsCreate {
+    mode: "create";
+    workspace: WorkspaceAddress;
+    filename: string; // must not exist
+}
+interface StorageSqliteOptsOpen {
+    mode: "open";
+    workspace: WorkspaceAddress | null;
+    filename: string; // must exist
+}
+interface StorageSqliteOptsCreateOrOpen {
+    mode: "create-or-open";
+    workspace: WorkspaceAddress;
+    filename: string; // may or may not exist
+}
+export type StorageSqliteNodeOpts =
+    | StorageSqliteOptsCreate
+    | StorageSqliteOptsOpen
+    | StorageSqliteOptsCreateOrOpen;
+
+interface ConfigObject extends Sqlite.RowObject {
+    key: string;
+    content: string;
+}
+
+interface DocObject extends Sqlite.RowObject {
+    format: string;
+    workspace: string;
+    path: string;
+    contentHash: string;
+    content: Uint8Array;
+    author: string;
+    timestamp: number;
+    deleteAfter: number;
+    signature: string;
+    localIndex?: number;
+    toSortWithinPath?: number;
+}
+
+export class StorageDriverSqlite implements IStorageDriverAsync {
+    workspace: WorkspaceAddress;
+    _filename: string;
+    _isClosed = false;
+    _db: Sqlite.DB = null as unknown as Sqlite.DB;
+    _maxLocalIndex: number;
+
+    //--------------------------------------------------
+    // LIFECYCLE
+
+    close(erase: boolean): Promise<void> {
+        logger.debug("close");
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        if (this._db) {
+            this._db.close();
+        }
+        // delete the sqlite file
+        if (erase === true && this._filename !== ":memory:") {
+            logger.log(`...close: and erase`);
+            try {
+                Deno.removeSync(this._filename);
+            } catch (err) {
+                logger.error("Failed to delete Sqlite file.");
+                logger.error(err);
+            }
+        }
+        this._isClosed = true;
+        logger.debug("...close is done.");
+
+        return Promise.resolve();
+    }
+
+    isClosed(): boolean {
+        return this._isClosed;
+    }
+
+    constructor(opts: StorageSqliteNodeOpts) {
+        this._filename = opts.filename;
+        this.workspace = "NOT_INITIALIZED";
+
+        // check if file exists
+        if (opts.mode === "create") {
+            if (opts.filename !== ":memory:") {
+                try {
+                    // If no file is found, this will throw.
+                    Deno.openSync(opts.filename);
+
+                    this.close(false);
+                    throw new EarthstarError(
+                        `Tried to create an sqlite file but it already exists: ${opts.filename}`,
+                    );
+                } finally {
+                    // Continue as normal
+                }
+            }
+        } else if (opts.mode === "open") {
+            if (opts.filename === ":memory:") {
+                this.close(false);
+                throw new EarthstarError(
+                    `Tried to open :memory: as though it was a file`,
+                );
+            }
+
+            try {
+                Deno.openSync(opts.filename);
+            } catch {
+                this.close(false);
+                throw new EarthstarError(
+                    `Tried to open an sqlite file but it doesn't exist: ${opts.filename}`,
+                );
+            }
+        } else if (opts.mode === "create-or-open") {
+            // file can exist or not.
+        } else {
+            // unknown mode
+            this.close(false);
+            throw new EarthstarError(
+                `sqlite unrecognized opts.mode: ${(opts as any).mode}`,
+            );
+        }
+
+        this._db = new Sqlite.DB(this._filename, { memory: this._filename === ":memory:" });
+        this._ensureTables();
+
+        const maxLocalIndexQuery = this._db
+            .prepareQuery<[number]>(
+                `
+                SELECT MAX(localIndex) from docs;
+        `,
+            );
+
+        const [maxLocalIndexFromDb] = maxLocalIndexQuery.one();
+        maxLocalIndexQuery.finalize();
+
+        this._maxLocalIndex = maxLocalIndexFromDb || -1;
+
+        // check workspace
+        if (opts.mode === "create") {
+            // workspace is provided; set it into the file which we know didn't exist until just now
+            this.workspace = opts.workspace;
+            this.setConfig("workspace", this.workspace);
+        } else if (opts.mode === "open") {
+            // load existing workspace from file, which we know already existed...
+            const existingWorkspace = this._getConfigSync("workspace");
+            if (existingWorkspace === undefined) {
+                this.close(false);
+                throw new EarthstarError(
+                    `can't open sqlite file with opts.mode="open" because the file doesn't have a workspace saved in its config table. ${opts.filename}`,
+                );
+            }
+            // if it was also provided in opts, assert that it matches the file
+            if (
+                opts.workspace !== null &&
+                opts.workspace !== this._getConfigSync("workspace")
+            ) {
+                this.close(false);
+                throw new EarthstarError(
+                    `sqlite with opts.mode="open" wanted workspace ${opts.workspace} but found ${existingWorkspace} in the file ${opts.filename}`,
+                );
+            }
+            this.workspace = existingWorkspace;
+        } else if (opts.mode === "create-or-open") {
+            // workspace must be provided
+            if (opts.workspace === null) {
+                this.close(false);
+                throw new EarthstarError(
+                    'sqlite with opts.mode="create-or-open" must have a workspace provided, not null',
+                );
+            }
+            this.workspace = opts.workspace;
+
+            // existing workspace can be undefined (file may not have existed yet)
+            let existingWorkspace = this._getConfigSync("workspace");
+
+            // if there is an existing workspace, it has to match the one given in opts
+            if (
+                existingWorkspace !== undefined &&
+                opts.workspace !== existingWorkspace
+            ) {
+                this.close(false);
+                throw new EarthstarError(
+                    `sqlite file had existing workspace ${existingWorkspace} but opts wanted it to be ${opts.workspace} in file ${opts.filename}`,
+                );
+            }
+
+            // set workspace if it's not set yet
+            if (existingWorkspace === undefined) {
+                this.setConfig("workspace", opts.workspace);
+            }
+
+            this.workspace = opts.workspace;
+        }
+
+        // check and set schemaVersion
+        let schemaVersion = this._getConfigSync("schemaVersion");
+        logger.log(`constructor    schemaVersion: ${schemaVersion}`);
+
+        if (schemaVersion === undefined) {
+            schemaVersion = "1";
+            this.setConfig("schemaVersion", schemaVersion);
+        } else if (schemaVersion !== "1") {
+            this.close(false);
+            throw new ValidationError(
+                `sqlite file ${this._filename} has unknown schema version ${schemaVersion}`,
+            );
+        }
+
+        // get maxlocalindex
+    }
+
+    //--------------------------------------------------
+    // CONFIG
+
+    setConfig(key: string, content: string): Promise<void> {
+        logger.debug(
+            `setConfig(${JSON.stringify(key)} = ${JSON.stringify(content)})`,
+        );
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        this._db
+            .query(
+                `
+					INSERT OR REPLACE INTO config (key, content) VALUES (:key, :content);
+			`,
+                { key: key, content: content },
+            );
+
+        return Promise.resolve();
+    }
+
+    _getConfigSync(key: string): string | undefined {
+        const configQuery = this._db
+            .prepareQuery<Sqlite.Row, ConfigObject>(
+                `SELECT content FROM config WHERE key = :key;`,
+            );
+
+        try {
+            const row = configQuery.oneEntry({ key });
+            const result = row.content;
+
+            logger.debug(
+                `getConfig(${JSON.stringify(key)}) = ${JSON.stringify(result)}`,
+            );
+
+            return result;
+        } catch {
+            return undefined;
+        } finally {
+            configQuery.finalize();
+        }
+    }
+
+    _listConfigKeysSync(): string[] {
+        const keysQuery = this._db
+            .prepareQuery<string[]>(
+                `
+					SELECT key FROM config;
+			`,
+            );
+
+        const rows = keysQuery.all();
+
+        keysQuery.finalize();
+
+        return sortedInPlace(rows.map(([key]) => key));
+    }
+
+    getConfig(key: string): Promise<string | undefined> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        return Promise.resolve(this._getConfigSync(key));
+    }
+
+    listConfigKeys(): Promise<string[]> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        return Promise.resolve(this._listConfigKeysSync());
+    }
+
+    deleteConfig(key: string): Promise<boolean> {
+        logger.debug(`deleteConfig(${JSON.stringify(key)})`);
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        this._db
+            .query(
+                `
+					DELETE FROM config WHERE key = :key;
+			`,
+                { key: key },
+            );
+
+        return Promise.resolve(this._db.changes > 0);
+    }
+
+    //--------------------------------------------------
+    // GET
+
+    getMaxLocalIndex(): number {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        return this._maxLocalIndex;
+    }
+
+    queryDocs(queryToClean: Query): Promise<Doc[]> {
+        // Query the documents
+
+        logger.debug("queryDocs", queryToClean);
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        // clean up the query and exit early if possible.
+        const { query, willMatch } = cleanUpQuery(queryToClean);
+        logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
+        if (willMatch === "nothing") {
+            return Promise.resolve([]);
+        }
+        const now = Date.now() * 1000;
+
+        const { sql, params } = this._makeDocQuerySql(query, now, "documents");
+        logger.debug("  sql:", sql);
+        logger.debug("  params:", params);
+
+        const docsQuery = this._db.prepareQuery<Sqlite.Row, DocObject>(sql);
+
+        const docs = docsQuery.allEntries(params);
+
+        if (query.historyMode === "latest") {
+            // remove extra field we added to find the winner within each path
+            docs.forEach((d) => {
+                delete d.toSortWithinPath;
+            });
+        }
+
+        // TODO: limitBytes, when this is added back to Query
+
+        // Transform the content from the DB (saved as BLOB) back to string
+
+        const docsWithStringContent = docs.map((doc) => ({
+            ...doc,
+            content: doc.content ? bytesToString(doc.content) : "",
+            _localIndex: doc.localIndex,
+        }));
+
+        docsWithStringContent.forEach((doc) => delete doc.localIndex);
+        docsWithStringContent.forEach((doc) => Object.freeze(doc));
+        logger.debug(`  result: ${docs.length} docs`);
+
+        docsQuery.finalize();
+        return Promise.resolve(docsWithStringContent);
+    }
+
+    //--------------------------------------------------
+    // SET
+
+    upsert(doc: Doc): Promise<Doc> {
+        // Insert new doc, replacing old doc if there is one
+        logger.debug(`upsertDocument(doc.path: ${JSON.stringify(doc.path)})`);
+
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        Object.freeze(doc);
+        const docWithLocalIndex = {
+            ...doc,
+            _localIndex: this._maxLocalIndex + 1,
+        };
+
+        this._maxLocalIndex += 1;
+
+        const contentAsBytes = stringToBytes(doc.content);
+
+        const docWithBytes = {
+            ...docWithLocalIndex,
+            content: contentAsBytes,
+        };
+
+        this._db
+            .query(
+                `
+					INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
+					VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);
+			`,
+                docWithBytes,
+            );
+
+        return Promise.resolve(docWithLocalIndex);
+    }
+
+    //--------------------------------------------------
+    // SQL STUFF
+
+    _ensureTables() {
+        // for each path and author we can have at most one document
+
+        // TODO: how to tell if we're loading an old sqlite file with old schema?
+
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        // make sure sqlite is using utf-8
+        this._db.query(`
+            PRAGMA encoding = "UTF-8";
+            `);
+
+        const encoding = this._db.query(`
+        PRAGMA encoding;
+        `);
+
+        /*
+        if (res !== "UTF-8") {
+            throw new Error(
+                `sqlite encoding is stubbornly set to ${encoding} instead of UTF-8`,
+            );
+        }*/
+
+        this._db
+            .query(
+                `
+					CREATE TABLE IF NOT EXISTS docs (
+							format TEXT NOT NULL,
+							workspace TEXT NOT NULL,
+							path TEXT NOT NULL,
+							contentHash TEXT NOT NULL,
+							content BLOB NOT NULL,
+							author TEXT NOT NULL,
+							timestamp NUMBER NOT NULL,
+							deleteAfter NUMBER,  -- can be null
+							signature TEXT NOT NULL,
+							localIndex NUMBER NOT NULL UNIQUE,
+							PRIMARY KEY(path, author)
+					);
+			`,
+            );
+
+        this._db
+            .query(`CREATE INDEX IF NOT EXISTS idx1 ON docs(localIndex);`);
+
+        // the config table is used to store these variables:
+        //     workspace - the workspace this store was created for
+        //     schemaVersion
+        this._db
+            .query(
+                `
+					CREATE TABLE IF NOT EXISTS config (
+							key TEXT NOT NULL PRIMARY KEY,
+							content TEXT NOT NULL
+					);
+			`,
+            );
+    }
+
+    _makeDocQuerySql(
+        query: Query,
+        now: number,
+        mode: "documents" | "delete",
+    ): { sql: string; params: Record<string, any> } {
+        /**
+         * Internal function to make SQL to query for documents or paths,
+         * or delete documents matching a query.
+         *
+         * Assumes query has already been through cleanUpQuery(q).
+         *
+         * If query.history === 'all', we can do an easy query:
+         *
+         * ```
+         *     SELECT * from DOCS
+         *     WHERE path = "/abc"
+         *         AND timestamp > 123
+         *     ORDER BY path ASC, author ASC
+         *     LIMIT 123
+         * ```
+         *
+         * If query.history === 'latest', we have to do something more complicated.
+         * We don't want to filter out some docs, and THEN get the latest REMAINING
+         * docs in each path.
+         * We want to first get the latest doc per path, THEN filter those.
+         *
+         * ```
+         *     SELECT *, MAX(timestamp) from DOCS
+         *     -- first level of filtering happens before we choose the latest doc.
+         *     -- here we can only do things that are the same for all docs in a path.
+         *     WHERE path = "/abc"
+         *     -- now group by path and keep the newest one
+         *     GROUP BY path
+         *     -- finally, second level of filtering happens AFTER we choose the latest doc.
+         *     -- these are things that can differ for docs within a path
+         *     HAVING timestamp > 123
+         *     ORDER BY path ASC, author ASC
+         *     LIMIT 123
+         * ```
+         */
+
+        let select = "";
+        let from = "FROM docs";
+        let wheres: string[] = [];
+        let groupBy = "";
+        let havings: string[] = [];
+        let orderBy = "";
+        let limit = "";
+
+        switch (query.orderBy) {
+            case "path ASC":
+                //   "path ASC" is actually "path ASC then break ties with timestamp DESC"
+                orderBy = "ORDER BY path ASC, timestamp DESC";
+                break;
+            case "path DESC":
+                //   "path DESC" is the reverse of that
+                orderBy = "ORDER BY path DESC, timestamp ASC";
+                break;
+            case "localIndex ASC":
+                orderBy = "ORDER BY localIndex ASC";
+                break;
+            case "localIndex DESC":
+                orderBy = "ORDER BY localIndex DESC";
+                break;
+        }
+
+        const params: Record<string, any> = {};
+        let sql = "";
+
+        if (mode === "documents") {
+            if (query.historyMode === "all") {
+                select = "SELECT *";
+            } else if (query.historyMode === "latest") {
+                // We're going to GROUP BY path and want to get the doc with the highest timestamp.
+                // To break timestamp ties, we'll use the signature.
+                // Because we need to look at multiple columns to choose the winner of the group
+                // we can't just do MAX(timestamp), we have to do this silly thing instead:
+                // TODO: test sorting by signature when timestamp is tied
+                select =
+                    "SELECT *, MIN(CAST(9999999999999999 - timestamp AS TEXT) || signature) AS toSortWithinPath";
+                //select = 'SELECT *, MAX(timestamp) AS toSortWithinPath';
+                groupBy = "GROUP BY path";
+            } else {
+                throw new ValidationError(
+                    `unexpected query.historyMode = ${query.historyMode}`,
+                );
+            }
+        } else if (mode === "delete") {
+            if (query.historyMode === "all") {
+                select = "DELETE";
+            } else {
+                throw new ValidationError(
+                    `query.history must be "all" when doing forgetDocuments`,
+                );
+            }
+        } else {
+            // if (mode === 'paths') {
+
+            throw new Error("unknown mode to _makeDocQuerySql: " + mode);
+            //select = 'SELECT DISTINCT path';
+        }
+
+        // parts of the query that are the same for all docs in a path can go in WHERE.
+
+        if (query.filter?.path !== undefined) {
+            wheres.push("path = :path");
+            params.path = query.filter.path;
+        }
+        // If we have pathStartsWith AND pathEndsWith we would want to optimize them
+        // into a single filter, path LIKE (:startsWith || '%' || :endsWith).
+        // BUT we can't do that because we are allowing the prefix and suffix
+        // to potentially overlap,
+        // leaving no room in the middle for the wildcard to match anything.
+        // So this has to be left as two separate filter clauses.
+        if (query.filter?.pathStartsWith !== undefined) {
+            // Escape existing % and _ in the prefix so they don't count as wildcards for LIKE.
+            // TODO: test this
+            wheres.push("path LIKE (:startsWith || '%') ESCAPE '\\'");
+            params.startsWith = query.filter.pathStartsWith
+                .split("_")
+                .join("\\_")
+                .split("%")
+                .join("\\%");
+        }
+        if (query.filter?.pathEndsWith !== undefined) {
+            // Escape existing % and _ in the suffix so they don't count as wildcards for LIKE.
+            // TODO: test this
+            wheres.push("path LIKE ('%' || :endsWith) ESCAPE '\\'");
+            params.endsWith = query.filter.pathEndsWith
+                .split("_")
+                .join("\\_")
+                .split("%")
+                .join("\\%");
+        }
+
+        // parts of the query that differ across docs in the same path
+        // may have to go in HAVING if we're doing a GROUP BY.
+        if (query.filter?.timestamp !== undefined) {
+            havings.push("timestamp = :timestamp");
+            params.timestamp = query.filter.timestamp;
+        }
+        if (query.filter?.timestampGt !== undefined) {
+            havings.push("timestamp > :timestampGt");
+            params.timestampGt = query.filter.timestampGt;
+        }
+        if (query.filter?.timestampLt !== undefined) {
+            havings.push("timestamp < :timestampLt");
+            params.timestampLt = query.filter.timestampLt;
+        }
+        if (query.filter?.author !== undefined) {
+            havings.push("author = :author");
+            params.author = query.filter.author;
+        }
+        // Sqlite length() counts unicode characters for TEXT and bytes for BLOB.
+        if (query.filter?.contentLength !== undefined) {
+            havings.push("length(content) = :contentLength");
+            params.contentLength = query.filter.contentLength;
+        }
+        if (query.filter?.contentLengthGt !== undefined) {
+            havings.push("length(content) > :contentLengthGt");
+            params.contentLengthGt = query.filter.contentLengthGt;
+        }
+        if (query.filter?.contentLengthLt !== undefined) {
+            havings.push("length(content) < :contentLengthLt");
+            params.contentLengthLt = query.filter.contentLengthLt;
+        }
+
+        if (query.startAfter !== undefined) {
+            if (query.orderBy?.startsWith("path ")) {
+                havings.push("path > :continuePath");
+                params.continuePath = query.startAfter.path;
+            } else if (query.orderBy?.startsWith("localIndex ")) {
+                havings.push("localIndex > :continueLocalIndex");
+                params.continueLocalIndex = query.startAfter.localIndex;
+            }
+        }
+
+        if (query.limit !== undefined && mode !== "delete") {
+            limit = "LIMIT :limit";
+            params.limit = query.limit;
+        }
+
+        // limitBytes is skipped here since it can't be expressed in SQL.
+        // it's applied after the query is run, and only for docs (not paths).
+
+        // filter out expired docs.
+        // to pretend they don't exist at all, we use WHERE instead of HAVING.
+        // otherwise they might end up as a latest doc of a group,
+        // and then disqualify that group.
+        wheres.push("(deleteAfter IS NULL OR :now <= deleteAfter)");
+        params.now = now;
+
+        // assemble the final sql
+
+        // in 'all' mode, we don't need to use HAVING, we can do all the filters as WHERE.
+        if (query.historyMode === "all") {
+            wheres = wheres.concat(havings);
+            havings = [];
+        }
+
+        const allWheres = wheres.length === 0 ? "" : "WHERE " + wheres.join("\n  AND ");
+        const allHavings = havings.length === 0 ? "" : "HAVING " + havings.join("\n  AND ");
+
+        sql = `
+					${select}
+					${from}
+					${allWheres}
+					${groupBy}
+					${allHavings}
+					${orderBy}
+					${limit};
+			`;
+
+        return { sql, params };
+    }
+}

--- a/src/storage/storage-driver-sqlite.deno.ts
+++ b/src/storage/storage-driver-sqlite.deno.ts
@@ -16,7 +16,7 @@ import {
     UPSERT_CONFIG_QUERY,
     UPSERT_DOC_QUERY,
 } from "./storage-driver-sqlite.shared.ts";
-import { Sqlite } from "../../deps.ts";
+import * as Sqlite from "https://deno.land/x/sqlite@v3.2.0/mod.ts";
 
 //--------------------------------------------------
 

--- a/src/storage/storage-driver-sqlite.deno.ts
+++ b/src/storage/storage-driver-sqlite.deno.ts
@@ -47,6 +47,7 @@ interface DocObject extends Sqlite.RowObject {
     toSortWithinPath?: number;
 }
 
+/** A strorage driver which persists to SQLite. Works in Deno and browsers. */
 export class StorageDriverSqlite implements IStorageDriverAsync {
     workspace: WorkspaceAddress;
     _filename: string;

--- a/src/storage/storage-driver-sqlite.node.ts
+++ b/src/storage/storage-driver-sqlite.node.ts
@@ -1,0 +1,628 @@
+import { Doc, WorkspaceAddress } from "../util/doc-types.ts";
+import { EarthstarError, StorageIsClosedError, ValidationError } from "../util/errors.ts";
+import { IStorageDriverAsync } from "./storage-types.ts";
+import { Database as SqliteDatabase, default as sqlite } from "https://esm.sh/better-sqlite3?dts";
+import * as fs from "https://deno.land/std@0.123.0/node/fs.ts";
+
+//--------------------------------------------------
+
+import { Logger } from "../util/log.ts";
+import { bytesToString, stringToBytes } from "../util/bytes.ts";
+import { Query } from "../query/query-types.ts";
+import { cleanUpQuery } from "../query/query.ts";
+import { sortedInPlace } from "./compare.ts";
+let logger = new Logger("storage driver sqlite node", "yellow");
+
+interface StorageSqliteOptsCreate {
+    mode: "create";
+    workspace: WorkspaceAddress;
+    filename: string; // must not exist
+}
+interface StorageSqliteOptsOpen {
+    mode: "open";
+    workspace: WorkspaceAddress | null;
+    filename: string; // must exist
+}
+interface StorageSqliteOptsCreateOrOpen {
+    mode: "create-or-open";
+    workspace: WorkspaceAddress;
+    filename: string; // may or may not exist
+}
+export type StorageSqliteNodeOpts =
+    | StorageSqliteOptsCreate
+    | StorageSqliteOptsOpen
+    | StorageSqliteOptsCreateOrOpen;
+
+export class StorageDriverSqlite implements IStorageDriverAsync {
+    workspace: WorkspaceAddress;
+    _filename: string;
+    _isClosed: boolean = false;
+    _db: SqliteDatabase = null as unknown as SqliteDatabase;
+    _maxLocalIndex: number;
+
+    //--------------------------------------------------
+    // LIFECYCLE
+
+    async close(erase: boolean): Promise<void> {
+        logger.debug("close");
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        if (this._db) {
+            this._db.close();
+        }
+        // delete the sqlite file
+        if (erase === true && this._filename !== ":memory:") {
+            logger.log(`...close: and erase`);
+            if (fs.existsSync(this._filename)) {
+                fs.unlinkSync(this._filename);
+            }
+        }
+        this._isClosed = true;
+        logger.debug("...close is done.");
+    }
+
+    isClosed(): boolean {
+        return this._isClosed;
+    }
+
+    constructor(opts: StorageSqliteNodeOpts) {
+        this._filename = opts.filename;
+        this.workspace = "NOT_INITIALIZED";
+
+        // check if file exists
+        if (opts.mode === "create") {
+            if (opts.filename !== ":memory:" && fs.existsSync(opts.filename)) {
+                this.close(false);
+                throw new EarthstarError(
+                    `Tried to create an sqlite file but it already exists: ${opts.filename}`,
+                );
+            }
+        } else if (opts.mode === "open") {
+            // this should also fail if you try to open :memory:
+            if (!fs.existsSync(opts.filename)) {
+                this.close(false);
+                throw new EarthstarError(
+                    `Tried to open an sqlite file but it doesn't exist: ${opts.filename}`,
+                );
+            }
+        } else if (opts.mode === "create-or-open") {
+            // file can exist or not.
+        } else {
+            // unknown mode
+            this.close(false);
+            throw new EarthstarError(
+                `sqlite unrecognized opts.mode: ${(opts as any).mode}`,
+            );
+        }
+
+        this._db = sqlite(this._filename);
+        this._ensureTables();
+
+        const maxLocalIndexFromDb = this._db
+            .prepare(
+                `
+					SELECT MAX(localIndex) from docs;
+			`,
+            )
+            .get();
+
+        this._maxLocalIndex = maxLocalIndexFromDb["MAX(localIndex)"] || -1;
+
+        // check workspace
+        if (opts.mode === "create") {
+            // workspace is provided; set it into the file which we know didn't exist until just now
+            this.workspace = opts.workspace;
+            this.setConfig("workspace", this.workspace);
+        } else if (opts.mode === "open") {
+            // load existing workspace from file, which we know already existed...
+            let existingWorkspace = this._getConfigSync("workspace");
+            if (existingWorkspace === undefined) {
+                this.close(false);
+                throw new EarthstarError(
+                    `can't open sqlite file with opts.mode="open" because the file doesn't have a workspace saved in its config table. ${opts.filename}`,
+                );
+            }
+            // if it was also provided in opts, assert that it matches the file
+            if (
+                opts.workspace !== null &&
+                opts.workspace !== this._getConfigSync("workspace")
+            ) {
+                this.close(false);
+                throw new EarthstarError(
+                    `sqlite with opts.mode="open" wanted workspace ${opts.workspace} but found ${existingWorkspace} in the file ${opts.filename}`,
+                );
+            }
+            this.workspace = existingWorkspace;
+        } else if (opts.mode === "create-or-open") {
+            // workspace must be provided
+            if (opts.workspace === null) {
+                this.close(false);
+                throw new EarthstarError(
+                    'sqlite with opts.mode="create-or-open" must have a workspace provided, not null',
+                );
+            }
+            this.workspace = opts.workspace;
+
+            // existing workspace can be undefined (file may not have existed yet)
+            let existingWorkspace = this._getConfigSync("workspace");
+
+            // if there is an existing workspace, it has to match the one given in opts
+            if (
+                existingWorkspace !== undefined &&
+                opts.workspace !== existingWorkspace
+            ) {
+                this.close(false);
+                throw new EarthstarError(
+                    `sqlite file had existing workspace ${existingWorkspace} but opts wanted it to be ${opts.workspace} in file ${opts.filename}`,
+                );
+            }
+
+            // set workspace if it's not set yet
+            if (existingWorkspace === undefined) {
+                this.setConfig("workspace", opts.workspace);
+            }
+
+            this.workspace = opts.workspace;
+        }
+
+        // check and set schemaVersion
+        let schemaVersion = this._getConfigSync("schemaVersion");
+        logger.log(`constructor    schemaVersion: ${schemaVersion}`);
+        /* istanbul ignore else */
+        if (schemaVersion === undefined) {
+            schemaVersion = "1";
+            this.setConfig("schemaVersion", schemaVersion);
+        } else if (schemaVersion !== "1") {
+            this.close(false);
+            throw new ValidationError(
+                `sqlite file ${this._filename} has unknown schema version ${schemaVersion}`,
+            );
+        }
+
+        // get maxlocalindex
+    }
+
+    //--------------------------------------------------
+    // CONFIG
+
+    async setConfig(key: string, content: string): Promise<void> {
+        logger.debug(
+            `setConfig(${JSON.stringify(key)} = ${JSON.stringify(content)})`,
+        );
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        this._db
+            .prepare(
+                `
+					INSERT OR REPLACE INTO config (key, content) VALUES (:key, :content);
+			`,
+            )
+            .run({ key: key, content: content });
+    }
+
+    _getConfigSync(key: string): string | undefined {
+        const row = this._db
+            .prepare(
+                `
+					SELECT content FROM config WHERE key = :key;
+			`,
+            )
+            .get({ key: key });
+        const result = row === undefined ? undefined : row.content;
+        logger.debug(
+            `getConfig(${JSON.stringify(key)}) = ${JSON.stringify(result)}`,
+        );
+        return result;
+    }
+
+    _listConfigKeysSync(): string[] {
+        const rows = this._db
+            .prepare(
+                `
+					SELECT key FROM config;
+			`,
+            )
+            .all();
+        return sortedInPlace(rows.map((row) => row.key));
+    }
+
+    async getConfig(key: string): Promise<string | undefined> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        return this._getConfigSync(key);
+    }
+
+    async listConfigKeys(): Promise<string[]> {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        return this._listConfigKeysSync();
+    }
+
+    async deleteConfig(key: string): Promise<boolean> {
+        logger.debug(`deleteConfig(${JSON.stringify(key)})`);
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+        const result = this._db
+            .prepare(
+                `
+					DELETE FROM config WHERE key = :key;
+			`,
+            )
+            .run({ key: key });
+
+        return result.changes > 0;
+    }
+
+    //--------------------------------------------------
+    // GET
+
+    getMaxLocalIndex(): number {
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        return this._maxLocalIndex;
+    }
+
+    async queryDocs(queryToClean: Query): Promise<Doc[]> {
+        // Query the documents
+
+        logger.debug("queryDocs", queryToClean);
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        // clean up the query and exit early if possible.
+        let { query, willMatch } = cleanUpQuery(queryToClean);
+        logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
+        if (willMatch === "nothing") {
+            return [];
+        }
+        let now = Date.now() * 1000;
+
+        let { sql, params } = this._makeDocQuerySql(query, now, "documents");
+        logger.debug("  sql:", sql);
+        logger.debug("  params:", params);
+
+        let docs = this._db.prepare(sql).all(params);
+
+        if (query.historyMode === "latest") {
+            // remove extra field we added to find the winner within each path
+            docs.forEach((d) => {
+                delete (d as any).toSortWithinPath;
+            });
+        }
+
+        // TODO: limitBytes, when this is added back to Query
+
+        // Transform the content from the DB (saved as BLOB) back to string
+        const docsWithStringContent = docs.map((doc) => ({
+            ...doc,
+            content: bytesToString(doc.content),
+            _localIndex: doc.localIndex,
+        }));
+
+        docsWithStringContent.forEach((doc) => delete doc["localIndex"]);
+        docsWithStringContent.forEach((doc) => Object.freeze(doc));
+        logger.debug(`  result: ${docs.length} docs`);
+        return docsWithStringContent;
+    }
+
+    //--------------------------------------------------
+    // SET
+
+    async upsert(doc: Doc): Promise<Doc> {
+        // Insert new doc, replacing old doc if there is one
+        logger.debug(`upsertDocument(doc.path: ${JSON.stringify(doc.path)})`);
+
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        Object.freeze(doc);
+        const docWithLocalIndex = {
+            ...doc,
+            _localIndex: this._maxLocalIndex + 1,
+        };
+
+        this._maxLocalIndex += 1;
+
+        const contentAsBytes = stringToBytes(doc.content);
+
+        const docWithBuffer = {
+            ...docWithLocalIndex,
+            content: contentAsBytes,
+        };
+
+        this._db
+            .prepare(
+                `
+					INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
+					VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);
+			`,
+            )
+            .run(docWithBuffer);
+
+        return docWithLocalIndex;
+    }
+
+    //--------------------------------------------------
+    // SQL STUFF
+
+    _ensureTables() {
+        // for each path and author we can have at most one document
+
+        // TODO: how to tell if we're loading an old sqlite file with old schema?
+
+        if (this._isClosed) {
+            throw new StorageIsClosedError();
+        }
+
+        // make sure sqlite is using utf-8
+        let encoding = this._db.pragma("encoding", { simple: true });
+        if (encoding !== "UTF-8") {
+            throw new Error(
+                `sqlite encoding is stubbornly set to ${encoding} instead of UTF-8`,
+            );
+        }
+
+        this._db
+            .prepare(
+                `
+					CREATE TABLE IF NOT EXISTS docs (
+							format TEXT NOT NULL,
+							workspace TEXT NOT NULL,
+							path TEXT NOT NULL,
+							contentHash TEXT NOT NULL,
+							content BLOB NOT NULL,
+							author TEXT NOT NULL,
+							timestamp NUMBER NOT NULL,
+							deleteAfter NUMBER,  -- can be null
+							signature TEXT NOT NULL,
+							localIndex NUMBER NOT NULL UNIQUE,
+							PRIMARY KEY(path, author)
+					);
+			`,
+            )
+            .run();
+
+        this._db
+            .prepare(`CREATE INDEX IF NOT EXISTS idx1 ON docs(localIndex);`)
+            .run();
+
+        // the config table is used to store these variables:
+        //     workspace - the workspace this store was created for
+        //     schemaVersion
+        this._db
+            .prepare(
+                `
+					CREATE TABLE IF NOT EXISTS config (
+							key TEXT NOT NULL PRIMARY KEY,
+							content TEXT NOT NULL
+					);
+			`,
+            )
+            .run();
+    }
+
+    _makeDocQuerySql(
+        query: Query,
+        now: number,
+        mode: "documents" | "delete",
+    ): { sql: string; params: Record<string, any> } {
+        /**
+         * Internal function to make SQL to query for documents or paths,
+         * or delete documents matching a query.
+         *
+         * Assumes query has already been through cleanUpQuery(q).
+         *
+         * If query.history === 'all', we can do an easy query:
+         *
+         * ```
+         *     SELECT * from DOCS
+         *     WHERE path = "/abc"
+         *         AND timestamp > 123
+         *     ORDER BY path ASC, author ASC
+         *     LIMIT 123
+         * ```
+         *
+         * If query.history === 'latest', we have to do something more complicated.
+         * We don't want to filter out some docs, and THEN get the latest REMAINING
+         * docs in each path.
+         * We want to first get the latest doc per path, THEN filter those.
+         *
+         * ```
+         *     SELECT *, MAX(timestamp) from DOCS
+         *     -- first level of filtering happens before we choose the latest doc.
+         *     -- here we can only do things that are the same for all docs in a path.
+         *     WHERE path = "/abc"
+         *     -- now group by path and keep the newest one
+         *     GROUP BY path
+         *     -- finally, second level of filtering happens AFTER we choose the latest doc.
+         *     -- these are things that can differ for docs within a path
+         *     HAVING timestamp > 123
+         *     ORDER BY path ASC, author ASC
+         *     LIMIT 123
+         * ```
+         */
+
+        let select = "";
+        let from = "FROM docs";
+        let wheres: string[] = [];
+        let groupBy = "";
+        let havings: string[] = [];
+        let orderBy = "";
+        let limit = "";
+
+        switch (query.orderBy) {
+            case "path ASC":
+                //   "path ASC" is actually "path ASC then break ties with timestamp DESC"
+                orderBy = "ORDER BY path ASC, timestamp DESC";
+                break;
+            case "path DESC":
+                //   "path DESC" is the reverse of that
+                orderBy = "ORDER BY path DESC, timestamp ASC";
+                break;
+            case "localIndex ASC":
+                orderBy = "ORDER BY localIndex ASC";
+                break;
+            case "localIndex DESC":
+                orderBy = "ORDER BY localIndex DESC";
+                break;
+        }
+
+        let params: Record<string, any> = {};
+        let sql = "";
+
+        if (mode === "documents") {
+            if (query.historyMode === "all") {
+                select = "SELECT *";
+            } else if (query.historyMode === "latest") {
+                // We're going to GROUP BY path and want to get the doc with the highest timestamp.
+                // To break timestamp ties, we'll use the signature.
+                // Because we need to look at multiple columns to choose the winner of the group
+                // we can't just do MAX(timestamp), we have to do this silly thing instead:
+                // TODO: test sorting by signature when timestamp is tied
+                select =
+                    "SELECT *, MIN(CAST(9999999999999999 - timestamp AS TEXT) || signature) AS toSortWithinPath";
+                //select = 'SELECT *, MAX(timestamp) AS toSortWithinPath';
+                groupBy = "GROUP BY path";
+            } else {
+                throw new ValidationError(
+                    `unexpected query.historyMode = ${query.historyMode}`,
+                );
+            }
+        } else if (mode === "delete") {
+            if (query.historyMode === "all") {
+                select = "DELETE";
+            } else {
+                throw new ValidationError(
+                    `query.history must be "all" when doing forgetDocuments`,
+                );
+            }
+        } else {
+            // if (mode === 'paths') {
+
+            throw new Error("unknown mode to _makeDocQuerySql: " + mode);
+            //select = 'SELECT DISTINCT path';
+        }
+
+        // parts of the query that are the same for all docs in a path can go in WHERE.
+
+        if (query.filter?.path !== undefined) {
+            wheres.push("path = :path");
+            params.path = query.filter.path;
+        }
+        // If we have pathStartsWith AND pathEndsWith we would want to optimize them
+        // into a single filter, path LIKE (:startsWith || '%' || :endsWith).
+        // BUT we can't do that because we are allowing the prefix and suffix
+        // to potentially overlap,
+        // leaving no room in the middle for the wildcard to match anything.
+        // So this has to be left as two separate filter clauses.
+        if (query.filter?.pathStartsWith !== undefined) {
+            // Escape existing % and _ in the prefix so they don't count as wildcards for LIKE.
+            // TODO: test this
+            wheres.push("path LIKE (:startsWith || '%') ESCAPE '\\'");
+            params.startsWith = query.filter.pathStartsWith
+                .split("_")
+                .join("\\_")
+                .split("%")
+                .join("\\%");
+        }
+        if (query.filter?.pathEndsWith !== undefined) {
+            // Escape existing % and _ in the suffix so they don't count as wildcards for LIKE.
+            // TODO: test this
+            wheres.push("path LIKE ('%' || :endsWith) ESCAPE '\\'");
+            params.endsWith = query.filter.pathEndsWith
+                .split("_")
+                .join("\\_")
+                .split("%")
+                .join("\\%");
+        }
+
+        // parts of the query that differ across docs in the same path
+        // may have to go in HAVING if we're doing a GROUP BY.
+        if (query.filter?.timestamp !== undefined) {
+            havings.push("timestamp = :timestamp");
+            params.timestamp = query.filter.timestamp;
+        }
+        if (query.filter?.timestampGt !== undefined) {
+            havings.push("timestamp > :timestampGt");
+            params.timestampGt = query.filter.timestampGt;
+        }
+        if (query.filter?.timestampLt !== undefined) {
+            havings.push("timestamp < :timestampLt");
+            params.timestampLt = query.filter.timestampLt;
+        }
+        if (query.filter?.author !== undefined) {
+            havings.push("author = :author");
+            params.author = query.filter.author;
+        }
+        // Sqlite length() counts unicode characters for TEXT and bytes for BLOB.
+        if (query.filter?.contentLength !== undefined) {
+            havings.push("length(content) = :contentLength");
+            params.contentLength = query.filter.contentLength;
+        }
+        if (query.filter?.contentLengthGt !== undefined) {
+            havings.push("length(content) > :contentLengthGt");
+            params.contentLengthGt = query.filter.contentLengthGt;
+        }
+        if (query.filter?.contentLengthLt !== undefined) {
+            havings.push("length(content) < :contentLengthLt");
+            params.contentLengthLt = query.filter.contentLengthLt;
+        }
+
+        if (query.startAfter !== undefined) {
+            if (query.orderBy?.startsWith("path ")) {
+                havings.push("path > :continuePath");
+                params.continuePath = query.startAfter.path;
+            } else if (query.orderBy?.startsWith("localIndex ")) {
+                havings.push("localIndex > :continueLocalIndex");
+                params.continueLocalIndex = query.startAfter.localIndex;
+            }
+        }
+
+        if (query.limit !== undefined && mode !== "delete") {
+            limit = "LIMIT :limit";
+            params.limit = query.limit;
+        }
+
+        // limitBytes is skipped here since it can't be expressed in SQL.
+        // it's applied after the query is run, and only for docs (not paths).
+
+        // filter out expired docs.
+        // to pretend they don't exist at all, we use WHERE instead of HAVING.
+        // otherwise they might end up as a latest doc of a group,
+        // and then disqualify that group.
+        wheres.push("(deleteAfter IS NULL OR :now <= deleteAfter)");
+        params.now = now;
+
+        // assemble the final sql
+
+        // in 'all' mode, we don't need to use HAVING, we can do all the filters as WHERE.
+        if (query.historyMode === "all") {
+            wheres = wheres.concat(havings);
+            havings = [];
+        }
+
+        let allWheres = wheres.length === 0 ? "" : "WHERE " + wheres.join("\n  AND ");
+        let allHavings = havings.length === 0 ? "" : "HAVING " + havings.join("\n  AND ");
+
+        sql = `
+					${select}
+					${from}
+					${allWheres}
+					${groupBy}
+					${allHavings}
+					${orderBy}
+					${limit};
+			`;
+
+        return { sql, params };
+    }
+}

--- a/src/storage/storage-driver-sqlite.node.ts
+++ b/src/storage/storage-driver-sqlite.node.ts
@@ -3,6 +3,19 @@ import { EarthstarError, StorageIsClosedError, ValidationError } from "../util/e
 import { IStorageDriverAsync } from "./storage-types.ts";
 import { Database as SqliteDatabase, default as sqlite } from "https://esm.sh/better-sqlite3?dts";
 import * as fs from "https://deno.land/std@0.123.0/node/fs.ts";
+import {
+    CREATE_CONFIG_TABLE_QUERY,
+    CREATE_DOCS_TABLE_QUERY,
+    CREATE_LOCAL_INDEX_INDEX_QUERY,
+    DELETE_CONFIG_QUERY,
+    makeDocQuerySql,
+    MAX_LOCAL_INDEX_QUERY,
+    SELECT_CONFIG_CONTENT_QUERY,
+    SELECT_KEY_CONFIG_QUERY,
+    StorageSqliteOpts,
+    UPSERT_CONFIG_QUERY,
+    UPSERT_DOC_QUERY,
+} from "./storage-driver-sqlite.shared.ts";
 
 //--------------------------------------------------
 
@@ -11,39 +24,19 @@ import { bytesToString, stringToBytes } from "../util/bytes.ts";
 import { Query } from "../query/query-types.ts";
 import { cleanUpQuery } from "../query/query.ts";
 import { sortedInPlace } from "./compare.ts";
-let logger = new Logger("storage driver sqlite node", "yellow");
-
-interface StorageSqliteOptsCreate {
-    mode: "create";
-    workspace: WorkspaceAddress;
-    filename: string; // must not exist
-}
-interface StorageSqliteOptsOpen {
-    mode: "open";
-    workspace: WorkspaceAddress | null;
-    filename: string; // must exist
-}
-interface StorageSqliteOptsCreateOrOpen {
-    mode: "create-or-open";
-    workspace: WorkspaceAddress;
-    filename: string; // may or may not exist
-}
-export type StorageSqliteNodeOpts =
-    | StorageSqliteOptsCreate
-    | StorageSqliteOptsOpen
-    | StorageSqliteOptsCreateOrOpen;
+const logger = new Logger("storage driver sqlite node", "yellow");
 
 export class StorageDriverSqlite implements IStorageDriverAsync {
     workspace: WorkspaceAddress;
     _filename: string;
-    _isClosed: boolean = false;
+    _isClosed = false;
     _db: SqliteDatabase = null as unknown as SqliteDatabase;
     _maxLocalIndex: number;
 
     //--------------------------------------------------
     // LIFECYCLE
 
-    async close(erase: boolean): Promise<void> {
+    close(erase: boolean): Promise<void> {
         logger.debug("close");
         if (this._isClosed) {
             throw new StorageIsClosedError();
@@ -60,13 +53,15 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         }
         this._isClosed = true;
         logger.debug("...close is done.");
+
+        return Promise.resolve();
     }
 
     isClosed(): boolean {
         return this._isClosed;
     }
 
-    constructor(opts: StorageSqliteNodeOpts) {
+    constructor(opts: StorageSqliteOpts) {
         this._filename = opts.filename;
         this.workspace = "NOT_INITIALIZED";
 
@@ -99,13 +94,7 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         this._db = sqlite(this._filename);
         this._ensureTables();
 
-        const maxLocalIndexFromDb = this._db
-            .prepare(
-                `
-					SELECT MAX(localIndex) from docs;
-			`,
-            )
-            .get();
+        const maxLocalIndexFromDb = this._db.prepare(MAX_LOCAL_INDEX_QUERY).get();
 
         this._maxLocalIndex = maxLocalIndexFromDb["MAX(localIndex)"] || -1;
 
@@ -116,7 +105,7 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
             this.setConfig("workspace", this.workspace);
         } else if (opts.mode === "open") {
             // load existing workspace from file, which we know already existed...
-            let existingWorkspace = this._getConfigSync("workspace");
+            const existingWorkspace = this._getConfigSync("workspace");
             if (existingWorkspace === undefined) {
                 this.close(false);
                 throw new EarthstarError(
@@ -145,7 +134,7 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
             this.workspace = opts.workspace;
 
             // existing workspace can be undefined (file may not have existed yet)
-            let existingWorkspace = this._getConfigSync("workspace");
+            const existingWorkspace = this._getConfigSync("workspace");
 
             // if there is an existing workspace, it has to match the one given in opts
             if (
@@ -186,30 +175,20 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
     //--------------------------------------------------
     // CONFIG
 
-    async setConfig(key: string, content: string): Promise<void> {
+    setConfig(key: string, content: string): Promise<void> {
         logger.debug(
             `setConfig(${JSON.stringify(key)} = ${JSON.stringify(content)})`,
         );
         if (this._isClosed) {
             throw new StorageIsClosedError();
         }
-        this._db
-            .prepare(
-                `
-					INSERT OR REPLACE INTO config (key, content) VALUES (:key, :content);
-			`,
-            )
-            .run({ key: key, content: content });
+        this._db.prepare(UPSERT_CONFIG_QUERY).run({ key: key, content: content });
+
+        return Promise.resolve();
     }
 
     _getConfigSync(key: string): string | undefined {
-        const row = this._db
-            .prepare(
-                `
-					SELECT content FROM config WHERE key = :key;
-			`,
-            )
-            .get({ key: key });
+        const row = this._db.prepare(SELECT_CONFIG_CONTENT_QUERY).get({ key: key });
         const result = row === undefined ? undefined : row.content;
         logger.debug(
             `getConfig(${JSON.stringify(key)}) = ${JSON.stringify(result)}`,
@@ -218,44 +197,32 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
     }
 
     _listConfigKeysSync(): string[] {
-        const rows = this._db
-            .prepare(
-                `
-					SELECT key FROM config;
-			`,
-            )
-            .all();
+        const rows = this._db.prepare(SELECT_KEY_CONFIG_QUERY).all();
         return sortedInPlace(rows.map((row) => row.key));
     }
 
-    async getConfig(key: string): Promise<string | undefined> {
+    getConfig(key: string): Promise<string | undefined> {
         if (this._isClosed) {
             throw new StorageIsClosedError();
         }
-        return this._getConfigSync(key);
+        return Promise.resolve(this._getConfigSync(key));
     }
 
-    async listConfigKeys(): Promise<string[]> {
+    listConfigKeys(): Promise<string[]> {
         if (this._isClosed) {
             throw new StorageIsClosedError();
         }
-        return this._listConfigKeysSync();
+        return Promise.resolve(this._listConfigKeysSync());
     }
 
-    async deleteConfig(key: string): Promise<boolean> {
+    deleteConfig(key: string): Promise<boolean> {
         logger.debug(`deleteConfig(${JSON.stringify(key)})`);
         if (this._isClosed) {
             throw new StorageIsClosedError();
         }
-        const result = this._db
-            .prepare(
-                `
-					DELETE FROM config WHERE key = :key;
-			`,
-            )
-            .run({ key: key });
+        const result = this._db.prepare(DELETE_CONFIG_QUERY).run({ key: key });
 
-        return result.changes > 0;
+        return Promise.resolve(result.changes > 0);
     }
 
     //--------------------------------------------------
@@ -269,7 +236,7 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         return this._maxLocalIndex;
     }
 
-    async queryDocs(queryToClean: Query): Promise<Doc[]> {
+    queryDocs(queryToClean: Query): Promise<Doc[]> {
         // Query the documents
 
         logger.debug("queryDocs", queryToClean);
@@ -278,18 +245,18 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         }
 
         // clean up the query and exit early if possible.
-        let { query, willMatch } = cleanUpQuery(queryToClean);
+        const { query, willMatch } = cleanUpQuery(queryToClean);
         logger.debug(`    cleanUpQuery.  willMatch = ${willMatch}`);
         if (willMatch === "nothing") {
-            return [];
+            return Promise.resolve([]);
         }
-        let now = Date.now() * 1000;
+        const now = Date.now() * 1000;
 
-        let { sql, params } = this._makeDocQuerySql(query, now, "documents");
+        const { sql, params } = makeDocQuerySql(query, now, "documents");
         logger.debug("  sql:", sql);
         logger.debug("  params:", params);
 
-        let docs = this._db.prepare(sql).all(params);
+        const docs = this._db.prepare(sql).all(params);
 
         if (query.historyMode === "latest") {
             // remove extra field we added to find the winner within each path
@@ -310,13 +277,13 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         docsWithStringContent.forEach((doc) => delete doc["localIndex"]);
         docsWithStringContent.forEach((doc) => Object.freeze(doc));
         logger.debug(`  result: ${docs.length} docs`);
-        return docsWithStringContent;
+        return Promise.resolve(docsWithStringContent);
     }
 
     //--------------------------------------------------
     // SET
 
-    async upsert(doc: Doc): Promise<Doc> {
+    upsert(doc: Doc): Promise<Doc> {
         // Insert new doc, replacing old doc if there is one
         logger.debug(`upsertDocument(doc.path: ${JSON.stringify(doc.path)})`);
 
@@ -339,16 +306,9 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
             content: contentAsBytes,
         };
 
-        this._db
-            .prepare(
-                `
-					INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
-					VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);
-			`,
-            )
-            .run(docWithBuffer);
+        this._db.prepare(UPSERT_DOC_QUERY).run(docWithBuffer);
 
-        return docWithLocalIndex;
+        return Promise.resolve(docWithLocalIndex);
     }
 
     //--------------------------------------------------
@@ -364,265 +324,19 @@ export class StorageDriverSqlite implements IStorageDriverAsync {
         }
 
         // make sure sqlite is using utf-8
-        let encoding = this._db.pragma("encoding", { simple: true });
+        const encoding = this._db.pragma("encoding", { simple: true });
         if (encoding !== "UTF-8") {
             throw new Error(
                 `sqlite encoding is stubbornly set to ${encoding} instead of UTF-8`,
             );
         }
 
-        this._db
-            .prepare(
-                `
-					CREATE TABLE IF NOT EXISTS docs (
-							format TEXT NOT NULL,
-							workspace TEXT NOT NULL,
-							path TEXT NOT NULL,
-							contentHash TEXT NOT NULL,
-							content BLOB NOT NULL,
-							author TEXT NOT NULL,
-							timestamp NUMBER NOT NULL,
-							deleteAfter NUMBER,  -- can be null
-							signature TEXT NOT NULL,
-							localIndex NUMBER NOT NULL UNIQUE,
-							PRIMARY KEY(path, author)
-					);
-			`,
-            )
-            .run();
-
-        this._db
-            .prepare(`CREATE INDEX IF NOT EXISTS idx1 ON docs(localIndex);`)
-            .run();
+        this._db.prepare(CREATE_DOCS_TABLE_QUERY).run();
+        this._db.prepare(CREATE_LOCAL_INDEX_INDEX_QUERY).run();
 
         // the config table is used to store these variables:
         //     workspace - the workspace this store was created for
         //     schemaVersion
-        this._db
-            .prepare(
-                `
-					CREATE TABLE IF NOT EXISTS config (
-							key TEXT NOT NULL PRIMARY KEY,
-							content TEXT NOT NULL
-					);
-			`,
-            )
-            .run();
-    }
-
-    _makeDocQuerySql(
-        query: Query,
-        now: number,
-        mode: "documents" | "delete",
-    ): { sql: string; params: Record<string, any> } {
-        /**
-         * Internal function to make SQL to query for documents or paths,
-         * or delete documents matching a query.
-         *
-         * Assumes query has already been through cleanUpQuery(q).
-         *
-         * If query.history === 'all', we can do an easy query:
-         *
-         * ```
-         *     SELECT * from DOCS
-         *     WHERE path = "/abc"
-         *         AND timestamp > 123
-         *     ORDER BY path ASC, author ASC
-         *     LIMIT 123
-         * ```
-         *
-         * If query.history === 'latest', we have to do something more complicated.
-         * We don't want to filter out some docs, and THEN get the latest REMAINING
-         * docs in each path.
-         * We want to first get the latest doc per path, THEN filter those.
-         *
-         * ```
-         *     SELECT *, MAX(timestamp) from DOCS
-         *     -- first level of filtering happens before we choose the latest doc.
-         *     -- here we can only do things that are the same for all docs in a path.
-         *     WHERE path = "/abc"
-         *     -- now group by path and keep the newest one
-         *     GROUP BY path
-         *     -- finally, second level of filtering happens AFTER we choose the latest doc.
-         *     -- these are things that can differ for docs within a path
-         *     HAVING timestamp > 123
-         *     ORDER BY path ASC, author ASC
-         *     LIMIT 123
-         * ```
-         */
-
-        let select = "";
-        let from = "FROM docs";
-        let wheres: string[] = [];
-        let groupBy = "";
-        let havings: string[] = [];
-        let orderBy = "";
-        let limit = "";
-
-        switch (query.orderBy) {
-            case "path ASC":
-                //   "path ASC" is actually "path ASC then break ties with timestamp DESC"
-                orderBy = "ORDER BY path ASC, timestamp DESC";
-                break;
-            case "path DESC":
-                //   "path DESC" is the reverse of that
-                orderBy = "ORDER BY path DESC, timestamp ASC";
-                break;
-            case "localIndex ASC":
-                orderBy = "ORDER BY localIndex ASC";
-                break;
-            case "localIndex DESC":
-                orderBy = "ORDER BY localIndex DESC";
-                break;
-        }
-
-        let params: Record<string, any> = {};
-        let sql = "";
-
-        if (mode === "documents") {
-            if (query.historyMode === "all") {
-                select = "SELECT *";
-            } else if (query.historyMode === "latest") {
-                // We're going to GROUP BY path and want to get the doc with the highest timestamp.
-                // To break timestamp ties, we'll use the signature.
-                // Because we need to look at multiple columns to choose the winner of the group
-                // we can't just do MAX(timestamp), we have to do this silly thing instead:
-                // TODO: test sorting by signature when timestamp is tied
-                select =
-                    "SELECT *, MIN(CAST(9999999999999999 - timestamp AS TEXT) || signature) AS toSortWithinPath";
-                //select = 'SELECT *, MAX(timestamp) AS toSortWithinPath';
-                groupBy = "GROUP BY path";
-            } else {
-                throw new ValidationError(
-                    `unexpected query.historyMode = ${query.historyMode}`,
-                );
-            }
-        } else if (mode === "delete") {
-            if (query.historyMode === "all") {
-                select = "DELETE";
-            } else {
-                throw new ValidationError(
-                    `query.history must be "all" when doing forgetDocuments`,
-                );
-            }
-        } else {
-            // if (mode === 'paths') {
-
-            throw new Error("unknown mode to _makeDocQuerySql: " + mode);
-            //select = 'SELECT DISTINCT path';
-        }
-
-        // parts of the query that are the same for all docs in a path can go in WHERE.
-
-        if (query.filter?.path !== undefined) {
-            wheres.push("path = :path");
-            params.path = query.filter.path;
-        }
-        // If we have pathStartsWith AND pathEndsWith we would want to optimize them
-        // into a single filter, path LIKE (:startsWith || '%' || :endsWith).
-        // BUT we can't do that because we are allowing the prefix and suffix
-        // to potentially overlap,
-        // leaving no room in the middle for the wildcard to match anything.
-        // So this has to be left as two separate filter clauses.
-        if (query.filter?.pathStartsWith !== undefined) {
-            // Escape existing % and _ in the prefix so they don't count as wildcards for LIKE.
-            // TODO: test this
-            wheres.push("path LIKE (:startsWith || '%') ESCAPE '\\'");
-            params.startsWith = query.filter.pathStartsWith
-                .split("_")
-                .join("\\_")
-                .split("%")
-                .join("\\%");
-        }
-        if (query.filter?.pathEndsWith !== undefined) {
-            // Escape existing % and _ in the suffix so they don't count as wildcards for LIKE.
-            // TODO: test this
-            wheres.push("path LIKE ('%' || :endsWith) ESCAPE '\\'");
-            params.endsWith = query.filter.pathEndsWith
-                .split("_")
-                .join("\\_")
-                .split("%")
-                .join("\\%");
-        }
-
-        // parts of the query that differ across docs in the same path
-        // may have to go in HAVING if we're doing a GROUP BY.
-        if (query.filter?.timestamp !== undefined) {
-            havings.push("timestamp = :timestamp");
-            params.timestamp = query.filter.timestamp;
-        }
-        if (query.filter?.timestampGt !== undefined) {
-            havings.push("timestamp > :timestampGt");
-            params.timestampGt = query.filter.timestampGt;
-        }
-        if (query.filter?.timestampLt !== undefined) {
-            havings.push("timestamp < :timestampLt");
-            params.timestampLt = query.filter.timestampLt;
-        }
-        if (query.filter?.author !== undefined) {
-            havings.push("author = :author");
-            params.author = query.filter.author;
-        }
-        // Sqlite length() counts unicode characters for TEXT and bytes for BLOB.
-        if (query.filter?.contentLength !== undefined) {
-            havings.push("length(content) = :contentLength");
-            params.contentLength = query.filter.contentLength;
-        }
-        if (query.filter?.contentLengthGt !== undefined) {
-            havings.push("length(content) > :contentLengthGt");
-            params.contentLengthGt = query.filter.contentLengthGt;
-        }
-        if (query.filter?.contentLengthLt !== undefined) {
-            havings.push("length(content) < :contentLengthLt");
-            params.contentLengthLt = query.filter.contentLengthLt;
-        }
-
-        if (query.startAfter !== undefined) {
-            if (query.orderBy?.startsWith("path ")) {
-                havings.push("path > :continuePath");
-                params.continuePath = query.startAfter.path;
-            } else if (query.orderBy?.startsWith("localIndex ")) {
-                havings.push("localIndex > :continueLocalIndex");
-                params.continueLocalIndex = query.startAfter.localIndex;
-            }
-        }
-
-        if (query.limit !== undefined && mode !== "delete") {
-            limit = "LIMIT :limit";
-            params.limit = query.limit;
-        }
-
-        // limitBytes is skipped here since it can't be expressed in SQL.
-        // it's applied after the query is run, and only for docs (not paths).
-
-        // filter out expired docs.
-        // to pretend they don't exist at all, we use WHERE instead of HAVING.
-        // otherwise they might end up as a latest doc of a group,
-        // and then disqualify that group.
-        wheres.push("(deleteAfter IS NULL OR :now <= deleteAfter)");
-        params.now = now;
-
-        // assemble the final sql
-
-        // in 'all' mode, we don't need to use HAVING, we can do all the filters as WHERE.
-        if (query.historyMode === "all") {
-            wheres = wheres.concat(havings);
-            havings = [];
-        }
-
-        let allWheres = wheres.length === 0 ? "" : "WHERE " + wheres.join("\n  AND ");
-        let allHavings = havings.length === 0 ? "" : "HAVING " + havings.join("\n  AND ");
-
-        sql = `
-					${select}
-					${from}
-					${allWheres}
-					${groupBy}
-					${allHavings}
-					${orderBy}
-					${limit};
-			`;
-
-        return { sql, params };
+        this._db.prepare(CREATE_CONFIG_TABLE_QUERY).run();
     }
 }

--- a/src/storage/storage-driver-sqlite.node.ts
+++ b/src/storage/storage-driver-sqlite.node.ts
@@ -26,6 +26,7 @@ import { cleanUpQuery } from "../query/query.ts";
 import { sortedInPlace } from "./compare.ts";
 const logger = new Logger("storage driver sqlite node", "yellow");
 
+/** A strorage driver which persists to SQLite. Works in Node. */
 export class StorageDriverSqlite implements IStorageDriverAsync {
     workspace: WorkspaceAddress;
     _filename: string;

--- a/src/storage/storage-driver-sqlite.shared.ts
+++ b/src/storage/storage-driver-sqlite.shared.ts
@@ -21,6 +21,7 @@ export interface StorageSqliteOptsCreateOrOpen {
     workspace: WorkspaceAddress;
     filename: string; // may or may not exist
 }
+
 export type StorageSqliteOpts =
     | StorageSqliteOptsCreate
     | StorageSqliteOptsOpen

--- a/src/storage/storage-driver-sqlite.shared.ts
+++ b/src/storage/storage-driver-sqlite.shared.ts
@@ -1,0 +1,288 @@
+import { Doc, WorkspaceAddress } from "../util/doc-types.ts";
+import { ValidationError } from "../util/errors.ts";
+import { Query } from "../query/query-types.ts";
+
+// types
+
+export interface StorageSqliteOptsCreate {
+    mode: "create";
+    workspace: WorkspaceAddress;
+    filename: string; // must not exist
+}
+
+export interface StorageSqliteOptsOpen {
+    mode: "open";
+    workspace: WorkspaceAddress | null;
+    filename: string; // must exist
+}
+
+export interface StorageSqliteOptsCreateOrOpen {
+    mode: "create-or-open";
+    workspace: WorkspaceAddress;
+    filename: string; // may or may not exist
+}
+export type StorageSqliteOpts =
+    | StorageSqliteOptsCreate
+    | StorageSqliteOptsOpen
+    | StorageSqliteOptsCreateOrOpen;
+
+// SQL queries
+
+export const MAX_LOCAL_INDEX_QUERY = `SELECT MAX(localIndex) from docs;`;
+
+export const UPSERT_CONFIG_QUERY =
+    `INSERT OR REPLACE INTO config (key, content) VALUES (:key, :content);`;
+
+export const SELECT_CONFIG_CONTENT_QUERY = `SELECT content FROM config WHERE key = :key;`;
+
+export const SELECT_KEY_CONFIG_QUERY = `SELECT key FROM config`;
+
+export const DELETE_CONFIG_QUERY = `DELETE FROM config WHERE key = :key;`;
+
+export const UPSERT_DOC_QUERY =
+    `INSERT OR REPLACE INTO docs (format, workspace, path, contentHash, content, author, timestamp, deleteAfter, signature, localIndex)
+VALUES (:format, :workspace, :path, :contentHash, :content, :author, :timestamp, :deleteAfter, :signature, :_localIndex);`;
+
+export const SET_ENCODING_QUERY = `PRAGMA encoding = "UTF-8";`;
+
+export const GET_ENCODING_QUERY = `PRAGMA encoding;`;
+
+export const CREATE_DOCS_TABLE_QUERY = `CREATE TABLE IF NOT EXISTS docs (
+		format TEXT NOT NULL,
+		workspace TEXT NOT NULL,
+		path TEXT NOT NULL,
+		contentHash TEXT NOT NULL,
+		content BLOB NOT NULL,
+		author TEXT NOT NULL,
+		timestamp NUMBER NOT NULL,
+		deleteAfter NUMBER,  -- can be null
+		signature TEXT NOT NULL,
+		localIndex NUMBER NOT NULL UNIQUE,
+		PRIMARY KEY(path, author)
+);`;
+
+export const CREATE_LOCAL_INDEX_INDEX_QUERY =
+    `CREATE INDEX IF NOT EXISTS idx1 ON docs(localIndex);`;
+
+export const CREATE_CONFIG_TABLE_QUERY = `CREATE TABLE IF NOT EXISTS config (
+		key TEXT NOT NULL PRIMARY KEY,
+		content TEXT NOT NULL
+);`;
+
+// utilities
+
+export function makeDocQuerySql(
+    query: Query,
+    now: number,
+    mode: "documents" | "delete",
+): { sql: string; params: Record<string, any> } {
+    /**
+     * Internal function to make SQL to query for documents or paths,
+     * or delete documents matching a query.
+     *
+     * Assumes query has already been through cleanUpQuery(q).
+     *
+     * If query.history === 'all', we can do an easy query:
+     *
+     * ```
+     *     SELECT * from DOCS
+     *     WHERE path = "/abc"
+     *         AND timestamp > 123
+     *     ORDER BY path ASC, author ASC
+     *     LIMIT 123
+     * ```
+     *
+     * If query.history === 'latest', we have to do something more complicated.
+     * We don't want to filter out some docs, and THEN get the latest REMAINING
+     * docs in each path.
+     * We want to first get the latest doc per path, THEN filter those.
+     *
+     * ```
+     *     SELECT *, MAX(timestamp) from DOCS
+     *     -- first level of filtering happens before we choose the latest doc.
+     *     -- here we can only do things that are the same for all docs in a path.
+     *     WHERE path = "/abc"
+     *     -- now group by path and keep the newest one
+     *     GROUP BY path
+     *     -- finally, second level of filtering happens AFTER we choose the latest doc.
+     *     -- these are things that can differ for docs within a path
+     *     HAVING timestamp > 123
+     *     ORDER BY path ASC, author ASC
+     *     LIMIT 123
+     * ```
+     */
+
+    let select = "";
+    let from = "FROM docs";
+    let wheres: string[] = [];
+    let groupBy = "";
+    let havings: string[] = [];
+    let orderBy = "";
+    let limit = "";
+
+    switch (query.orderBy) {
+        case "path ASC":
+            //   "path ASC" is actually "path ASC then break ties with timestamp DESC"
+            orderBy = "ORDER BY path ASC, timestamp DESC";
+            break;
+        case "path DESC":
+            //   "path DESC" is the reverse of that
+            orderBy = "ORDER BY path DESC, timestamp ASC";
+            break;
+        case "localIndex ASC":
+            orderBy = "ORDER BY localIndex ASC";
+            break;
+        case "localIndex DESC":
+            orderBy = "ORDER BY localIndex DESC";
+            break;
+    }
+
+    const params: Record<string, any> = {};
+    let sql = "";
+
+    if (mode === "documents") {
+        if (query.historyMode === "all") {
+            select = "SELECT *";
+        } else if (query.historyMode === "latest") {
+            // We're going to GROUP BY path and want to get the doc with the highest timestamp.
+            // To break timestamp ties, we'll use the signature.
+            // Because we need to look at multiple columns to choose the winner of the group
+            // we can't just do MAX(timestamp), we have to do this silly thing instead:
+            // TODO: test sorting by signature when timestamp is tied
+            select =
+                "SELECT *, MIN(CAST(9999999999999999 - timestamp AS TEXT) || signature) AS toSortWithinPath";
+            //select = 'SELECT *, MAX(timestamp) AS toSortWithinPath';
+            groupBy = "GROUP BY path";
+        } else {
+            throw new ValidationError(
+                `unexpected query.historyMode = ${query.historyMode}`,
+            );
+        }
+    } else if (mode === "delete") {
+        if (query.historyMode === "all") {
+            select = "DELETE";
+        } else {
+            throw new ValidationError(
+                `query.history must be "all" when doing forgetDocuments`,
+            );
+        }
+    } else {
+        // if (mode === 'paths') {
+
+        throw new Error("unknown mode to _makeDocQuerySql: " + mode);
+        //select = 'SELECT DISTINCT path';
+    }
+
+    // parts of the query that are the same for all docs in a path can go in WHERE.
+
+    if (query.filter?.path !== undefined) {
+        wheres.push("path = :path");
+        params.path = query.filter.path;
+    }
+    // If we have pathStartsWith AND pathEndsWith we would want to optimize them
+    // into a single filter, path LIKE (:startsWith || '%' || :endsWith).
+    // BUT we can't do that because we are allowing the prefix and suffix
+    // to potentially overlap,
+    // leaving no room in the middle for the wildcard to match anything.
+    // So this has to be left as two separate filter clauses.
+    if (query.filter?.pathStartsWith !== undefined) {
+        // Escape existing % and _ in the prefix so they don't count as wildcards for LIKE.
+        // TODO: test this
+        wheres.push("path LIKE (:startsWith || '%') ESCAPE '\\'");
+        params.startsWith = query.filter.pathStartsWith
+            .split("_")
+            .join("\\_")
+            .split("%")
+            .join("\\%");
+    }
+    if (query.filter?.pathEndsWith !== undefined) {
+        // Escape existing % and _ in the suffix so they don't count as wildcards for LIKE.
+        // TODO: test this
+        wheres.push("path LIKE ('%' || :endsWith) ESCAPE '\\'");
+        params.endsWith = query.filter.pathEndsWith
+            .split("_")
+            .join("\\_")
+            .split("%")
+            .join("\\%");
+    }
+
+    // parts of the query that differ across docs in the same path
+    // may have to go in HAVING if we're doing a GROUP BY.
+    if (query.filter?.timestamp !== undefined) {
+        havings.push("timestamp = :timestamp");
+        params.timestamp = query.filter.timestamp;
+    }
+    if (query.filter?.timestampGt !== undefined) {
+        havings.push("timestamp > :timestampGt");
+        params.timestampGt = query.filter.timestampGt;
+    }
+    if (query.filter?.timestampLt !== undefined) {
+        havings.push("timestamp < :timestampLt");
+        params.timestampLt = query.filter.timestampLt;
+    }
+    if (query.filter?.author !== undefined) {
+        havings.push("author = :author");
+        params.author = query.filter.author;
+    }
+    // Sqlite length() counts unicode characters for TEXT and bytes for BLOB.
+    if (query.filter?.contentLength !== undefined) {
+        havings.push("length(content) = :contentLength");
+        params.contentLength = query.filter.contentLength;
+    }
+    if (query.filter?.contentLengthGt !== undefined) {
+        havings.push("length(content) > :contentLengthGt");
+        params.contentLengthGt = query.filter.contentLengthGt;
+    }
+    if (query.filter?.contentLengthLt !== undefined) {
+        havings.push("length(content) < :contentLengthLt");
+        params.contentLengthLt = query.filter.contentLengthLt;
+    }
+
+    if (query.startAfter !== undefined) {
+        if (query.orderBy?.startsWith("path ")) {
+            havings.push("path > :continuePath");
+            params.continuePath = query.startAfter.path;
+        } else if (query.orderBy?.startsWith("localIndex ")) {
+            havings.push("localIndex > :continueLocalIndex");
+            params.continueLocalIndex = query.startAfter.localIndex;
+        }
+    }
+
+    if (query.limit !== undefined && mode !== "delete") {
+        limit = "LIMIT :limit";
+        params.limit = query.limit;
+    }
+
+    // limitBytes is skipped here since it can't be expressed in SQL.
+    // it's applied after the query is run, and only for docs (not paths).
+
+    // filter out expired docs.
+    // to pretend they don't exist at all, we use WHERE instead of HAVING.
+    // otherwise they might end up as a latest doc of a group,
+    // and then disqualify that group.
+    wheres.push("(deleteAfter IS NULL OR :now <= deleteAfter)");
+    params.now = now;
+
+    // assemble the final sql
+
+    // in 'all' mode, we don't need to use HAVING, we can do all the filters as WHERE.
+    if (query.historyMode === "all") {
+        wheres = wheres.concat(havings);
+        havings = [];
+    }
+
+    const allWheres = wheres.length === 0 ? "" : "WHERE " + wheres.join("\n  AND ");
+    const allHavings = havings.length === 0 ? "" : "HAVING " + havings.join("\n  AND ");
+
+    sql = `
+			${select}
+			${from}
+			${allWheres}
+			${groupBy}
+			${allHavings}
+			${orderBy}
+			${limit};
+	`;
+
+    return { sql, params };
+}

--- a/src/test/improved/storage-config.test.ts
+++ b/src/test/improved/storage-config.test.ts
@@ -62,8 +62,8 @@ let _runStorageConfigTests = (
         );
         assertEquals(
             await storage.listConfigKeys(),
-            [],
-            `listConfigKeys() is [] when empty`,
+            [...scenario.builtInConfigKeys],
+            `listConfigKeys() only contains built-in config keys`,
         );
         assertEquals(
             await storage.deleteConfig("a"),
@@ -79,8 +79,8 @@ let _runStorageConfigTests = (
         assertEquals(await storage.getConfig("a"), "aa", `getConfig works`);
         assertEquals(
             await storage.listConfigKeys(),
-            ["a", "b"],
-            `listConfigKeys() is ['a', 'b'] (sorted)`,
+            ["a", "b", ...scenario.builtInConfigKeys],
+            `listConfigKeys() is ${["a", "b", ...scenario.builtInConfigKeys]} (sorted)`,
         );
 
         await storage.setConfig("a", "aaa");
@@ -108,8 +108,8 @@ let _runStorageConfigTests = (
         );
         assertEquals(
             await storage.listConfigKeys(),
-            ["b"],
-            `listConfigKeys() is ['b'] after deleting 'a'`,
+            ["b", ...scenario.builtInConfigKeys],
+            `listConfigKeys() is ${["b", ...scenario.builtInConfigKeys]} after deleting 'a'`,
         );
 
         // close without erasing

--- a/src/test/improved/storage-driver-async.test.ts
+++ b/src/test/improved/storage-driver-async.test.ts
@@ -75,8 +75,8 @@ export function runStorageDriverTests(scenario: TestScenario) {
         );
         assertEquals(
             await driver.listConfigKeys(),
-            [],
-            `listConfigKeys() is []`,
+            [...scenario.builtInConfigKeys],
+            `listConfigKeys() is ${[...scenario.builtInConfigKeys]}`,
         );
         assertEquals(
             await driver.deleteConfig("foo"),
@@ -92,8 +92,8 @@ export function runStorageDriverTests(scenario: TestScenario) {
         assertEquals(await driver.getConfig("a"), "aa", `getConfig works`);
         assertEquals(
             await driver.listConfigKeys(),
-            ["a", "b"],
-            `listConfigKeys() is ['a', 'b'] (sorted)`,
+            ["a", "b", ...scenario.builtInConfigKeys],
+            `listConfigKeys() is ${["a", "b", ...scenario.builtInConfigKeys]} (sorted)`,
         );
 
         assertEquals(
@@ -187,7 +187,7 @@ export function runStorageDriverTests(scenario: TestScenario) {
 
             let docs = await driver.queryDocs({});
             assertEquals(docs.length, 1, "query returns 1 doc");
-            assertEquals(docs[0]._localIndex, 0, "docs[0]._localIndex");
+            assertEquals(docs[0]._localIndex, 0, "docs[0]._localIndex is 0");
             assertEquals(docs[0].content, "Hello 0", "content is from doc0");
 
             //-----------------

--- a/src/test/test-scenario-types.ts
+++ b/src/test/test-scenario-types.ts
@@ -15,6 +15,9 @@ export interface TestScenario {
     // in here you will instantiate a StorageDriver and then
     // use it to instantiate a Storage:
     makeDriver: (ws: WorkspaceAddress) => IStorageDriverAsync;
+
+    // Config keys that come with the driver
+    builtInConfigKeys: string[];
 }
 
 export interface CryptoScenario {

--- a/src/test/test-scenarios.ts
+++ b/src/test/test-scenarios.ts
@@ -27,15 +27,6 @@ const universalStorageScenarios: JustStorageScenario[] = [
         makeDriver: (ws) => new StorageDriverAsyncMemory(ws),
         builtInConfigKeys: [],
     },
-];
-
-const browserStorageScenarios: JustStorageScenario[] = [
-    {
-        name: "StorageDriverLocalStorage",
-        persistent: true,
-        makeDriver: (ws) => new StorageDriverLocalStorage(ws),
-        builtInConfigKeys: [],
-    },
     {
         name: "StorageDriverSqlite",
         persistent: false,
@@ -46,6 +37,15 @@ const browserStorageScenarios: JustStorageScenario[] = [
                 workspace: ws,
             }),
         builtInConfigKeys: ["schemaVersion", "workspace"],
+    },
+];
+
+const browserStorageScenarios: JustStorageScenario[] = [
+    {
+        name: "StorageDriverLocalStorage",
+        persistent: true,
+        makeDriver: (ws) => new StorageDriverLocalStorage(ws),
+        builtInConfigKeys: [],
     },
 ];
 

--- a/src/test/test-scenarios.ts
+++ b/src/test/test-scenarios.ts
@@ -9,6 +9,7 @@ import { CryptoDriverChloride } from "../crypto/crypto-driver-chloride.ts";
 import { StorageDriverAsyncMemory } from "../storage/storage-driver-async-memory.ts";
 import { StorageDriverLocalStorage } from "../storage/storage-driver-local-storage.ts";
 import { StorageDriverIndexedDB } from "../storage/storage-driver-indexeddb.ts";
+import { StorageDriverSqlite } from "../storage/storage-driver-sqlite.deno.ts";
 
 // test types
 import { CryptoScenario, TestScenario } from "./test-scenario-types.ts";
@@ -24,6 +25,7 @@ const universalStorageScenarios: JustStorageScenario[] = [
         name: "StorageDriverAsyncMemory",
         persistent: false,
         makeDriver: (ws) => new StorageDriverAsyncMemory(ws),
+        builtInConfigKeys: [],
     },
 ];
 
@@ -32,6 +34,18 @@ const browserStorageScenarios: JustStorageScenario[] = [
         name: "StorageDriverLocalStorage",
         persistent: true,
         makeDriver: (ws) => new StorageDriverLocalStorage(ws),
+        builtInConfigKeys: [],
+    },
+    {
+        name: "StorageDriverSqlite",
+        persistent: false,
+        makeDriver: (ws) =>
+            new StorageDriverSqlite({
+                filename: ":memory:",
+                mode: "create",
+                workspace: ws,
+            }),
+        builtInConfigKeys: ["schemaVersion", "workspace"],
     },
 ];
 
@@ -40,6 +54,7 @@ const browserOnlyStorageScenarios: JustStorageScenario[] = [
         name: "StorageDriverIndexedDB",
         persistent: true,
         makeDriver: (ws) => new StorageDriverIndexedDB(ws),
+        builtInConfigKeys: [],
     },
 ];
 

--- a/src/util/bytes.ts
+++ b/src/util/bytes.ts
@@ -8,8 +8,8 @@
 
 import { rfc4648 } from "../../deps.ts";
 
-let decoder: TextDecoder = new TextDecoder();
-let encoder: TextEncoder = new TextEncoder();
+const decoder: TextDecoder = new TextDecoder();
+const encoder: TextEncoder = new TextEncoder();
 
 //--------------------------------------------------
 


### PR DESCRIPTION
## What's the problem you solved?

Existing storage drivers don't allow us to persist much data, save for IndexedDB, and that's browser-only. We need a driver that can persist a lot of data in runtimes like Node and Deno.

## What solution are you recommending?

- I've added two similar-but-annoyingly-different storage drivers for Sqlite, one for Node and one for Deno. 
  - I've tried to share common code between them in a practical way.
- I've modified test scenario configs to add a `builtInConfigKeys` property, so that tests won't fail when a storage is instantiated with certain config keys.
- I've made a separate `mod.browser.ts` as the entrypoint for `deno bundle`, otherwise SQLite was being bundled in there. Which works because it's WASM but it's massive.
- I've made sure the right things are exported in the NPM distribution.

Closes #155