### PR TITLE
Fix flakey tests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -14,4 +14,4 @@ export {
     TransportHttpClient,
     TransportLocal,
     TransportWebsocketClient,
-} from "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.0/mod.browser.ts";
+} from "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.1/mod.browser.ts";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -60,14 +60,14 @@ await build({
         target: "ES2020",
     },
     mappings: {
-        "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.0/mod.browser.ts":
+        "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.1/mod.browser.ts":
             {
                 name: "earthstar-streaming-rpc",
-                version: "3.2.0",
+                version: "3.2.1",
             },
-        "https://esm.sh/earthstar-streaming-rpc@3.2.0?dts": {
+        "https://esm.sh/earthstar-streaming-rpc@3.2.1?dts": {
             name: "earthstar-streaming-rpc",
-            version: "3.2.0",
+            version: "3.2.1",
         },
         "https://esm.sh/express?dts": {
             name: "express",

--- a/src/test/improved/peer-sync.test.ts
+++ b/src/test/improved/peer-sync.test.ts
@@ -20,15 +20,10 @@ Overall:
 	- Make sure everything is cleaned up after closing.
 */
 
-// TestContext type not exported to DNT test shims yet: https://github.com/denoland/node_deno_shims/issues/85
-type TestFn = Parameters<typeof Deno.test>["1"];
-type TestContext = Parameters<TestFn>["0"];
-
-async function testSyncScenario(
+function testSyncScenario(
     scenario: PeerSyncScenario,
-    test: TestContext,
 ) {
-    await test.step(`Peer.sync, Peer.stopSync + ${scenario.name}`, async () => {
+    Deno.test(`Peer.sync, Peer.stopSync + ${scenario.name}`, async () => {
         const keypairA = await Crypto.generateAuthorKeypair("suzy") as AuthorKeypair;
 
         const ADDRESS_A = "+apples.a123";
@@ -118,11 +113,8 @@ async function testSyncScenario(
     });
 }
 
-Deno.test("Peer sync", async (test) => {
-    for (const scenario of peerSyncScenarios) {
-        await testSyncScenario(
-            scenario,
-            test,
-        );
-    }
-});
+for (const scenario of peerSyncScenarios) {
+    testSyncScenario(
+        scenario,
+    );
+}

--- a/src/test/improved/peer-sync.test.ts
+++ b/src/test/improved/peer-sync.test.ts
@@ -23,7 +23,7 @@ Overall:
 function testSyncScenario(
     scenario: PeerSyncScenario,
 ) {
-    Deno.test(`Peer.sync, Peer.stopSync + ${scenario.name}`, async () => {
+    Deno.test(`Peer.sync, Peer.stopSync + ${scenario.name}`, async (test) => {
         const keypairA = await Crypto.generateAuthorKeypair("suzy") as AuthorKeypair;
 
         const ADDRESS_A = "+apples.a123";
@@ -69,10 +69,26 @@ function testSyncScenario(
         // Wait a sec
         await sleep(3000);
 
-        // Check that everything synced
-        assert(await storagesAreSynced(storagesATriplet), `All ${ADDRESS_A} storages synced`);
-        assert(await storagesAreSynced(storagesBTriplet), `All ${ADDRESS_B} storages synced`);
-        assert(await storagesAreSynced(storagesCTriplet), `All ${ADDRESS_C} storages synced`);
+        await test.step({
+            name: "Storages synced",
+            sanitizeOps: false,
+            sanitizeResources: false,
+            fn: async () => {
+                // Check that everything synced
+                assert(
+                    await storagesAreSynced(storagesATriplet),
+                    `All ${ADDRESS_A} storages synced`,
+                );
+                assert(
+                    await storagesAreSynced(storagesBTriplet),
+                    `All ${ADDRESS_B} storages synced`,
+                );
+                assert(
+                    await storagesAreSynced(storagesCTriplet),
+                    `All ${ADDRESS_C} storages synced`,
+                );
+            },
+        });
 
         // Now close the connections
         closers.forEach((closer) => closer());
@@ -95,8 +111,15 @@ function testSyncScenario(
 
         await sleep(1000);
 
-        const areDStoragesSynced = await storagesAreSynced(storagesDTriplet);
-        assert(areDStoragesSynced === false, `All ${ADDRESS_D} storages did NOT sync`);
+        await test.step({
+            name: "Storages did not sync after closing connection",
+            sanitizeOps: false,
+            sanitizeResources: false,
+            fn: async () => {
+                const areDStoragesSynced = await storagesAreSynced(storagesDTriplet);
+                assert(areDStoragesSynced === false, `All ${ADDRESS_D} storages did NOT sync`);
+            },
+        });
 
         // Wrap up.
 

--- a/src/test/test-deps.node.ts
+++ b/src/test/test-deps.node.ts
@@ -1,1 +1,1 @@
-export * as Rpc from "https://esm.sh/earthstar-streaming-rpc@3.2.0?dts";
+export * as Rpc from "https://esm.sh/earthstar-streaming-rpc@3.2.1?dts";

--- a/src/test/test-deps.ts
+++ b/src/test/test-deps.ts
@@ -1,3 +1,3 @@
 export { serve } from "https://deno.land/std@0.123.0/http/server.ts";
 export { type Opine, opine } from "https://deno.land/x/opine@2.1.1/mod.ts";
-export * as Rpc from "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.0/mod.ts";
+export * as Rpc from "https://raw.githubusercontent.com/earthstar-project/earthstar-streaming-rpc/v3.2.1/mod.ts";


### PR DESCRIPTION
## What's the problem you solved?

We had a few flakey tests, caused by not waiting long enough for syncing to happen and improper use of the test step API. Also there was an issue where earthstar-streaming-rpc would try to send a message after the websocket was closed.

## What solution are you recommending?

- Update earthstar-streaming-rpc to v3.2.1 with websocket fix
- Wait a little longer in syncing tests
- Use Deno's test step API properly so that failures don't cascade into other tests (e.g. by not closing a server after an assertion failure).